### PR TITLE
Initial the unit testing and add a unit test for the main class, Omise

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,4 +8,9 @@
             <directory>tests/unit/</directory>
         </testsuite>
     </testsuites>
+    <filter>
+        <whitelist>
+            <directory suffix=".php">omise</directory>
+        </whitelist>
+    </filter>
 </phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/5.5/phpunit.xsd"
+    bootstrap="tests/autoload.php">
+
+    <testsuites>
+        <testsuite name="Unit">
+            <directory>tests/unit/</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/autoload.php
+++ b/tests/autoload.php
@@ -1,0 +1,14 @@
+<?php
+function autoload($class) {
+    static $classes = null;
+
+    if ($classes === null) {
+        $classes = array('Omise' => 'omise.php');
+    }
+
+    if (isset($classes[$class])) {
+        require __DIR__ . '/../omise/' . $classes[$class];
+    }
+}
+
+spl_autoload_register('autoload');

--- a/tests/unit/OmiseTest.php
+++ b/tests/unit/OmiseTest.php
@@ -1,0 +1,37 @@
+<?php
+define('_PS_VERSION_', 'TEST_VERSION');
+
+class OmiseTest extends PHPUnit_Framework_TestCase
+{
+    private $omise;
+
+    public function setup()
+    {
+        $paymentModule = $this->getMockBuilder(stdClass::class)
+            ->setMockClassName('PaymentModule')
+            ->setMethods(array('__construct', 'l'))
+            ->getMock();
+
+        $this->omise = new Omise();
+    }
+
+    public function testName_omise()
+    {
+        $this->assertEquals('omise', $this->omise->name);
+    }
+
+    public function testDisplayName_Omise()
+    {
+        $this->assertEquals('Omise', $this->omise->displayName);
+    }
+
+    public function testNeedInstance_0()
+    {
+        $this->assertEquals(0, $this->omise->need_instance);
+    }
+
+    public function testBootstrap_true()
+    {
+        $this->assertEquals(true, $this->omise->bootstrap);
+    }
+}


### PR DESCRIPTION
**1. Objective reason**

To deliver quality software, the unit testing is one of many parts that can be achieved. It is easy to initial the unit testing at the beginning of the development.

Required pull request: [#1](https://github.com/omise/omise-prestashop/pull/1)

**2. Description of change**

Initial the unit testing and add a unit test for the main class, Omise. The unit testing will be run with PHPUnit.

Note:
1. To run unit test
   
   `$ phpunit`
2. To run unit test with code coverage reporting
   
   `$ phpunit --coverage-html report/`

From the second sample command, the report will be generated to the directory `report/`. It can be changed to another directory.

**3. Users affected by the change**

None

**4. Impact of the change**

`-`

**5. Priority of change**

Normal

**6. Alternate solution**

`-`
