### PR TITLE
Display the initial setting page

### DIFF
--- a/omise/omise.php
+++ b/omise/omise.php
@@ -47,82 +47,82 @@ class Omise extends PaymentModule
             'legend' => array(
                 'title' => $this->l('Settings')
             ),
-            'input' => array(
+            'input'  => array(
                 array(
-                    'type' => 'switch',
-                    'label' => $this->l('Enable/Disable'),
-                    'name' => 'module',
-                    'is_bool' => true,
-                    'desc' => $this->l('Enable Omise Payment Module.'),
-                    'values' => array(
+                    'type'     => 'switch',
+                    'label'    => $this->l('Enable/Disable'),
+                    'name'     => 'module',
+                    'is_bool'  => true,
+                    'desc'     => $this->l('Enable Omise Payment Module.'),
+                    'values'   => array(
                         array(
-                            'id' => 'module_enabled',
+                            'id'    => 'module_enabled',
                             'value' => 1,
                             'label' => 'Enabled'
                         ),
                         array(
-                            'id' => 'module_disabled',
+                            'id'    => 'module_disabled',
                             'value' => 0,
                             'label' => 'Disabled'
                         )
                     )
                 ),
                 array(
-                    'type' => 'switch',
-                    'label' => $this->l('Sandbox'),
-                    'name' => 'sandbox',
-                    'is_bool' => true,
-                    'desc' => $this->l('Enabling sandbox means that all your transactions will be in TEST mode.'),
-                    'values' => array(
+                    'type'     => 'switch',
+                    'label'    => $this->l('Sandbox'),
+                    'name'     => 'sandbox',
+                    'is_bool'  => true,
+                    'desc'     => $this->l('Enabling sandbox means that all your transactions will be in TEST mode.'),
+                    'values'   => array(
                         array(
-                            'id' => 'sandbox_on',
+                            'id'    => 'sandbox_on',
                             'value' => 1,
                             'label' => 'Enabled'
                         ),
                         array(
-                            'id' => 'sandbox_off',
+                            'id'    => 'sandbox_off',
                             'value' => 0,
                             'label' => 'Disabled'
                         )
                     )
                 ),
                 array(
-                    'type' => 'text',
-                    'label' => $this->l('Public key for test'),
-                    'name' => 'publicKeyForTest',
+                    'type'     => 'text',
+                    'label'    => $this->l('Public key for test'),
+                    'name'     => 'publicKeyForTest',
                     'required' => false,
-                    'desc' => 'The "Test" mode public key can be found in Omise Dashboard.'
+                    'desc'     => 'The "Test" mode public key can be found in Omise Dashboard.'
                 ),
                 array(
-                    'type' => 'text',
-                    'label' => $this->l('Secret key for test'),
-                    'name' => 'secretKeyForTest',
+                    'type'     => 'text',
+                    'label'    => $this->l('Secret key for test'),
+                    'name'     => 'secretKeyForTest',
                     'required' => false,
-                    'desc' => 'The "Test" mode secret key can be found in Omise Dashboard.'
+                    'desc'     => 'The "Test" mode secret key can be found in Omise Dashboard.'
                 ),
                 array(
-                    'type' => 'text',
-                    'label' => $this->l('Public key for live'),
-                    'name' => 'publicKeyForLive',
+                    'type'     => 'text',
+                    'label'    => $this->l('Public key for live'),
+                    'name'     => 'publicKeyForLive',
                     'required' => false,
-                    'desc' => 'The "Live" mode public key can be found in Omise Dashboard.'
+                    'desc'     => 'The "Live" mode public key can be found in Omise Dashboard.'
                 ),
                 array(
-                    'type' => 'text',
-                    'label' => $this->l('Secret key for live'),
-                    'name' => 'secretKeyForLive',
+                    'type'     => 'text',
+                    'label'    => $this->l('Secret key for live'),
+                    'name'     => 'secretKeyForLive',
                     'required' => false,
-                    'desc' => 'The "Live" mode secret key can be found in Omise Dashboard.'
+                    'desc'     => 'The "Live" mode secret key can be found in Omise Dashboard.'
                 ),
                 array(
-                    'label' => '<b>Advance Settings</b>'
+                    'label'    => '<b>Advance Settings</b>'
                 ),
                 array(
-                    'type' => 'text',
-                    'label' => $this->l('Title'),
-                    'name' => 'title',
+                    'type'     => 'text',
+                    'label'    => $this->l('Title'),
+                    'name'     => 'title',
                     'required' => false,
-                    'desc' => 'This controls the title which the user sees during checkout.'
+                    'desc'     => 'This controls the title which the user sees during checkout.'
                 )
             ),
             'submit' => array(

--- a/omise/omise.php
+++ b/omise/omise.php
@@ -40,4 +40,100 @@ class Omise extends PaymentModule
         $this->displayName            = self::MODULE_DISPLAY_NAME;
         $this->confirmUninstall       = $this->l('Are you sure you want to uninstall ' . self::MODULE_DISPLAY_NAME . ' module?');
     }
+
+    public function getContent()
+    {
+        $fields_form[0]['form'] = array(
+            'legend' => array(
+                'title' => $this->l('Settings')
+            ),
+            'input' => array(
+                array(
+                    'type' => 'switch',
+                    'label' => $this->l('Enable/Disable'),
+                    'name' => 'module',
+                    'is_bool' => true,
+                    'desc' => $this->l('Enable Omise Payment Module.'),
+                    'values' => array(
+                        array(
+                            'id' => 'module_enabled',
+                            'value' => 1,
+                            'label' => 'Enabled'
+                        ),
+                        array(
+                            'id' => 'module_disabled',
+                            'value' => 0,
+                            'label' => 'Disabled'
+                        )
+                    )
+                ),
+                array(
+                    'type' => 'switch',
+                    'label' => $this->l('Sandbox'),
+                    'name' => 'sandbox',
+                    'is_bool' => true,
+                    'desc' => $this->l('Enabling sandbox means that all your transactions will be in TEST mode.'),
+                    'values' => array(
+                        array(
+                            'id' => 'sandbox_on',
+                            'value' => 1,
+                            'label' => 'Enabled'
+                        ),
+                        array(
+                            'id' => 'sandbox_off',
+                            'value' => 0,
+                            'label' => 'Disabled'
+                        )
+                    )
+                ),
+                array(
+                    'type' => 'text',
+                    'label' => $this->l('Public key for test'),
+                    'name' => 'publicKeyForTest',
+                    'required' => false,
+                    'desc' => 'The "Test" mode public key can be found in Omise Dashboard.'
+                ),
+                array(
+                    'type' => 'text',
+                    'label' => $this->l('Secret key for test'),
+                    'name' => 'secretKeyForTest',
+                    'required' => false,
+                    'desc' => 'The "Test" mode secret key can be found in Omise Dashboard.'
+                ),
+                array(
+                    'type' => 'text',
+                    'label' => $this->l('Public key for live'),
+                    'name' => 'publicKeyForLive',
+                    'required' => false,
+                    'desc' => 'The "Live" mode public key can be found in Omise Dashboard.'
+                ),
+                array(
+                    'type' => 'text',
+                    'label' => $this->l('Secret key for live'),
+                    'name' => 'secretKeyForLive',
+                    'required' => false,
+                    'desc' => 'The "Live" mode secret key can be found in Omise Dashboard.'
+                ),
+                array(
+                    'label' => '<b>Advance Settings</b>'
+                ),
+                array(
+                    'type' => 'text',
+                    'label' => $this->l('Title'),
+                    'name' => 'title',
+                    'required' => false,
+                    'desc' => 'This controls the title which the user sees during checkout.'
+                )
+            ),
+            'submit' => array(
+                'title' => $this->l('Save'),
+                'class' => 'btn btn-default pull-right'
+            )
+        );
+
+        $helper = new HelperForm();
+        $helper->submit_action = 'submit' . $this->name;
+
+        return $helper->generateForm($fields_form);
+    }
 }


### PR DESCRIPTION
**1. Objective reason**

Display the controls at the setting page.

It is the display only. It has not been any function.

Required pull request: [#1](https://github.com/omise/omise-prestashop/pull/1)

**2. Description of change**

Implement a function, Omise.getContent(). Define the parameters for display the controls.

The screenshot below shows the setting page.

![screenshot-localhost 2016-09-10 16-46-35](https://cloud.githubusercontent.com/assets/4145121/18409635/42f2ced0-7776-11e6-9064-2d5b498573cd.png)

**3. Users affected by the change**

All

**4. Impact of the change**

`-`

**5. Priority of change**

Normal

**6. Alternate solution**

`-`
