### PR TITLE
Save the configuration

### DIFF
--- a/omise/form.php
+++ b/omise/form.php
@@ -1,0 +1,145 @@
+<?php
+if (! defined('_PS_VERSION_')) {
+    exit();
+}
+
+class Form extends PaymentModule
+{
+    protected $submit_action_name = 'submitOmiseForm';
+
+    public function generate()
+    {
+        $helper = new HelperForm();
+
+        $helper->submit_action = $this->submit_action_name;
+        $helper->fields_value['module'] = Configuration::get('module');
+        $helper->fields_value['sandbox'] = Configuration::get('sandbox');
+        $helper->fields_value['publicKeyForTest'] = Configuration::get('publicKeyForTest');
+        $helper->fields_value['secretKeyForTest'] = Configuration::get('secretKeyForTest');
+        $helper->fields_value['publicKeyForLive'] = Configuration::get('publicKeyForLive');
+        $helper->fields_value['secretKeyForLive'] = Configuration::get('secretKeyForLive');
+        $helper->fields_value['title'] = Configuration::get('title');
+
+        $fields = $this->getFields();
+
+        return $helper->generateForm($fields);
+    }
+
+    public function getFields()
+    {
+        $fields[0]['form'] = array(
+            'legend' => array(
+                'title' => $this->l('Settings')
+            ),
+            'input' => array(
+                array(
+                    'type' => 'switch',
+                    'label' => $this->l('Enable/Disable'),
+                    'name' => 'module',
+                    'is_bool' => true,
+                    'desc' => $this->l('Enable Omise Payment Module.'),
+                    'values' => array(
+                        array(
+                            'id' => 'module_enabled',
+                            'value' => 1,
+                            'label' => 'Enabled'
+                        ),
+                        array(
+                            'id' => 'module_disabled',
+                            'value' => 0,
+                            'label' => 'Disabled'
+                        )
+                    )
+                ),
+                array(
+                    'type' => 'switch',
+                    'label' => $this->l('Sandbox'),
+                    'name' => 'sandbox',
+                    'is_bool' => true,
+                    'desc' => $this->l('Enabling sandbox means that all your transactions will be in TEST mode.'),
+                    'values' => array(
+                        array(
+                            'id' => 'sandbox_on',
+                            'value' => 1,
+                            'label' => 'Enabled'
+                        ),
+                        array(
+                            'id' => 'sandbox_off',
+                            'value' => 0,
+                            'label' => 'Disabled'
+                        )
+                    )
+                ),
+                array(
+                    'type' => 'text',
+                    'label' => $this->l('Public key for test'),
+                    'name' => 'publicKeyForTest',
+                    'required' => false,
+                    'desc' => $this->l('The "Test" mode public key can be found in Omise Dashboard.')
+                ),
+                array(
+                    'type' => 'text',
+                    'label' => $this->l('Secret key for test'),
+                    'name' => 'secretKeyForTest',
+                    'required' => false,
+                    'desc' => $this->l('The "Test" mode secret key can be found in Omise Dashboard.')
+                ),
+                array(
+                    'type' => 'text',
+                    'label' => $this->l('Public key for live'),
+                    'name' => 'publicKeyForLive',
+                    'required' => false,
+                    'desc' => $this->l('The "Live" mode public key can be found in Omise Dashboard.')
+                ),
+                array(
+                    'type' => 'text',
+                    'label' => $this->l('Secret key for live'),
+                    'name' => 'secretKeyForLive',
+                    'required' => false,
+                    'desc' => $this->l('The "Live" mode secret key can be found in Omise Dashboard.')
+                ),
+                array(
+                    'label' => '<b>' . $this->l('Advance Settings') . '</b>'
+                ),
+                array(
+                    'type' => 'text',
+                    'label' => $this->l('Title'),
+                    'name' => 'title',
+                    'required' => false,
+                    'desc' => $this->l('This controls the title which the user sees during checkout.')
+                )
+            ),
+            'submit' => array(
+                'title' => $this->l('Save'),
+                'class' => 'btn btn-default pull-right'
+            )
+        );
+
+        return $fields;
+    }
+
+    public function isSubmit()
+    {
+        if (Tools::isSubmit($this->submit_action_name)) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    public function save()
+    {
+        Configuration::updateValue('module', strval(Tools::getValue('module')));
+        Configuration::updateValue('sandbox', strval(Tools::getValue('sandbox')));
+        Configuration::updateValue('publicKeyForTest', strval(Tools::getValue('publicKeyForTest')));
+        Configuration::updateValue('secretKeyForTest', strval(Tools::getValue('secretKeyForTest')));
+        Configuration::updateValue('publicKeyForLive', strval(Tools::getValue('publicKeyForLive')));
+        Configuration::updateValue('secretKeyForLive', strval(Tools::getValue('secretKeyForLive')));
+        Configuration::updateValue('title', strval(Tools::getValue('title')));
+    }
+
+    public function getSubmitActionName()
+    {
+        return $this->submit_action_name;
+    }
+}

--- a/omise/omise.php
+++ b/omise/omise.php
@@ -1,6 +1,9 @@
 <?php
-if (! defined('_PS_VERSION_'))
+if (! defined('_PS_VERSION_')) {
     exit();
+}
+
+require_once 'form.php';
 
 class Omise extends PaymentModule
 {
@@ -25,6 +28,8 @@ class Omise extends PaymentModule
      */
     const MODULE_VERSION = '1.6.0.0';
 
+    protected $form;
+
     public function __construct()
     {
         $this->name                   = self::MODULE_NAME;
@@ -39,101 +44,31 @@ class Omise extends PaymentModule
 
         $this->displayName            = self::MODULE_DISPLAY_NAME;
         $this->confirmUninstall       = $this->l('Are you sure you want to uninstall ' . self::MODULE_DISPLAY_NAME . ' module?');
+
+        $this->setForm(new Form());
     }
 
     public function getContent()
     {
-        $fields_form[0]['form'] = array(
-            'legend' => array(
-                'title' => $this->l('Settings')
-            ),
-            'input'  => array(
-                array(
-                    'type'     => 'switch',
-                    'label'    => $this->l('Enable/Disable'),
-                    'name'     => 'module',
-                    'is_bool'  => true,
-                    'desc'     => $this->l('Enable Omise Payment Module.'),
-                    'values'   => array(
-                        array(
-                            'id'    => 'module_enabled',
-                            'value' => 1,
-                            'label' => 'Enabled'
-                        ),
-                        array(
-                            'id'    => 'module_disabled',
-                            'value' => 0,
-                            'label' => 'Disabled'
-                        )
-                    )
-                ),
-                array(
-                    'type'     => 'switch',
-                    'label'    => $this->l('Sandbox'),
-                    'name'     => 'sandbox',
-                    'is_bool'  => true,
-                    'desc'     => $this->l('Enabling sandbox means that all your transactions will be in TEST mode.'),
-                    'values'   => array(
-                        array(
-                            'id'    => 'sandbox_on',
-                            'value' => 1,
-                            'label' => 'Enabled'
-                        ),
-                        array(
-                            'id'    => 'sandbox_off',
-                            'value' => 0,
-                            'label' => 'Disabled'
-                        )
-                    )
-                ),
-                array(
-                    'type'     => 'text',
-                    'label'    => $this->l('Public key for test'),
-                    'name'     => 'publicKeyForTest',
-                    'required' => false,
-                    'desc'     => 'The "Test" mode public key can be found in Omise Dashboard.'
-                ),
-                array(
-                    'type'     => 'text',
-                    'label'    => $this->l('Secret key for test'),
-                    'name'     => 'secretKeyForTest',
-                    'required' => false,
-                    'desc'     => 'The "Test" mode secret key can be found in Omise Dashboard.'
-                ),
-                array(
-                    'type'     => 'text',
-                    'label'    => $this->l('Public key for live'),
-                    'name'     => 'publicKeyForLive',
-                    'required' => false,
-                    'desc'     => 'The "Live" mode public key can be found in Omise Dashboard.'
-                ),
-                array(
-                    'type'     => 'text',
-                    'label'    => $this->l('Secret key for live'),
-                    'name'     => 'secretKeyForLive',
-                    'required' => false,
-                    'desc'     => 'The "Live" mode secret key can be found in Omise Dashboard.'
-                ),
-                array(
-                    'label'    => '<b>Advance Settings</b>'
-                ),
-                array(
-                    'type'     => 'text',
-                    'label'    => $this->l('Title'),
-                    'name'     => 'title',
-                    'required' => false,
-                    'desc'     => 'This controls the title which the user sees during checkout.'
-                )
-            ),
-            'submit' => array(
-                'title' => $this->l('Save'),
-                'class' => 'btn btn-default pull-right'
-            )
-        );
+        $content = '';
 
-        $helper = new HelperForm();
-        $helper->submit_action = 'submit' . $this->name;
+        if ($this->form->isSubmit()) {
+            $this->form->save();
+            $content .= $this->displayConfirmation($this->l('Settings updated'));
+        }
 
-        return $helper->generateForm($fields_form);
+        $content .= $this->form->generate();
+
+        return $content;
+    }
+
+    public function getForm()
+    {
+        return $this->form;
+    }
+
+    public function setForm($form)
+    {
+        $this->form = $form;
     }
 }

--- a/omise/omise.php
+++ b/omise/omise.php
@@ -3,7 +3,7 @@ if (! defined('_PS_VERSION_')) {
     exit();
 }
 
-require_once 'form.php';
+require_once 'setting.php';
 
 class Omise extends PaymentModule
 {
@@ -28,7 +28,7 @@ class Omise extends PaymentModule
      */
     const MODULE_VERSION = '1.6.0.0';
 
-    protected $form;
+    protected $setting;
 
     public function __construct()
     {
@@ -45,30 +45,30 @@ class Omise extends PaymentModule
         $this->displayName            = self::MODULE_DISPLAY_NAME;
         $this->confirmUninstall       = $this->l('Are you sure you want to uninstall ' . self::MODULE_DISPLAY_NAME . ' module?');
 
-        $this->setForm(new Form());
+        $this->setSetting(new Setting());
     }
 
     public function getContent()
     {
         $content = '';
 
-        if ($this->form->isSubmit()) {
-            $this->form->save();
+        if ($this->setting->isSubmit()) {
+            $this->setting->save();
             $content .= $this->displayConfirmation($this->l('Settings updated'));
         }
 
-        $content .= $this->form->generate();
+        $content .= $this->setting->generateForm();
 
         return $content;
     }
 
-    public function getForm()
+    public function getSetting()
     {
-        return $this->form;
+        return $this->setting;
     }
 
-    public function setForm($form)
+    public function setSetting($setting)
     {
-        $this->form = $form;
+        $this->setting = $setting;
     }
 }

--- a/omise/setting.php
+++ b/omise/setting.php
@@ -3,21 +3,21 @@ if (! defined('_PS_VERSION_')) {
     exit();
 }
 
-class Form extends PaymentModule
+class Setting extends PaymentModule
 {
-    protected $submit_action_name = 'submitOmiseForm';
+    protected $submit_action = 'omise_save_setting';
 
-    public function generate()
+    public function generateForm()
     {
         $helper = new HelperForm();
 
-        $helper->submit_action = $this->submit_action_name;
-        $helper->fields_value['module'] = Configuration::get('module');
-        $helper->fields_value['sandbox'] = Configuration::get('sandbox');
-        $helper->fields_value['publicKeyForTest'] = Configuration::get('publicKeyForTest');
-        $helper->fields_value['secretKeyForTest'] = Configuration::get('secretKeyForTest');
-        $helper->fields_value['publicKeyForLive'] = Configuration::get('publicKeyForLive');
-        $helper->fields_value['secretKeyForLive'] = Configuration::get('secretKeyForLive');
+        $helper->submit_action = $this->getSubmitAction();
+        $helper->fields_value['module_status'] = Configuration::get('module_status');
+        $helper->fields_value['sandbox_status'] = Configuration::get('sandbox_status');
+        $helper->fields_value['test_public_key'] = Configuration::get('test_public_key');
+        $helper->fields_value['test_secret_key'] = Configuration::get('test_secret_key');
+        $helper->fields_value['live_public_key'] = Configuration::get('live_public_key');
+        $helper->fields_value['live_secret_key'] = Configuration::get('live_secret_key');
         $helper->fields_value['title'] = Configuration::get('title');
 
         $fields = $this->getFields();
@@ -32,76 +32,76 @@ class Form extends PaymentModule
                 'title' => $this->l('Settings')
             ),
             'input' => array(
-                array(
+                'module_status' => array(
                     'type' => 'switch',
                     'label' => $this->l('Enable/Disable'),
-                    'name' => 'module',
+                    'name' => 'module_status',
                     'is_bool' => true,
                     'desc' => $this->l('Enable Omise Payment Module.'),
                     'values' => array(
                         array(
-                            'id' => 'module_enabled',
+                            'id' => 'module_status_enabled',
                             'value' => 1,
                             'label' => 'Enabled'
                         ),
                         array(
-                            'id' => 'module_disabled',
+                            'id' => 'module_status_disabled',
                             'value' => 0,
                             'label' => 'Disabled'
                         )
                     )
                 ),
-                array(
+                'sandbox_status' => array(
                     'type' => 'switch',
                     'label' => $this->l('Sandbox'),
-                    'name' => 'sandbox',
+                    'name' => 'sandbox_status',
                     'is_bool' => true,
                     'desc' => $this->l('Enabling sandbox means that all your transactions will be in TEST mode.'),
                     'values' => array(
                         array(
-                            'id' => 'sandbox_on',
+                            'id' => 'sandbox_status_enabled',
                             'value' => 1,
                             'label' => 'Enabled'
                         ),
                         array(
-                            'id' => 'sandbox_off',
+                            'id' => 'sandbox_status_disabled',
                             'value' => 0,
                             'label' => 'Disabled'
                         )
                     )
                 ),
-                array(
+                'test_public_key' => array(
                     'type' => 'text',
                     'label' => $this->l('Public key for test'),
-                    'name' => 'publicKeyForTest',
+                    'name' => 'test_public_key',
                     'required' => false,
                     'desc' => $this->l('The "Test" mode public key can be found in Omise Dashboard.')
                 ),
-                array(
+                'test_secret_key' => array(
                     'type' => 'text',
                     'label' => $this->l('Secret key for test'),
-                    'name' => 'secretKeyForTest',
+                    'name' => 'test_secret_key',
                     'required' => false,
                     'desc' => $this->l('The "Test" mode secret key can be found in Omise Dashboard.')
                 ),
-                array(
+                'live_public_key' => array(
                     'type' => 'text',
                     'label' => $this->l('Public key for live'),
-                    'name' => 'publicKeyForLive',
+                    'name' => 'live_public_key',
                     'required' => false,
                     'desc' => $this->l('The "Live" mode public key can be found in Omise Dashboard.')
                 ),
-                array(
+                'live_secret_key' => array(
                     'type' => 'text',
                     'label' => $this->l('Secret key for live'),
-                    'name' => 'secretKeyForLive',
+                    'name' => 'live_secret_key',
                     'required' => false,
                     'desc' => $this->l('The "Live" mode secret key can be found in Omise Dashboard.')
                 ),
-                array(
+                'advance_settings' => array(
                     'label' => '<b>' . $this->l('Advance Settings') . '</b>'
                 ),
-                array(
+                'title' => array(
                     'type' => 'text',
                     'label' => $this->l('Title'),
                     'name' => 'title',
@@ -120,7 +120,7 @@ class Form extends PaymentModule
 
     public function isSubmit()
     {
-        if (Tools::isSubmit($this->submit_action_name)) {
+        if (Tools::isSubmit($this->getSubmitAction())) {
             return true;
         } else {
             return false;
@@ -129,17 +129,17 @@ class Form extends PaymentModule
 
     public function save()
     {
-        Configuration::updateValue('module', strval(Tools::getValue('module')));
-        Configuration::updateValue('sandbox', strval(Tools::getValue('sandbox')));
-        Configuration::updateValue('publicKeyForTest', strval(Tools::getValue('publicKeyForTest')));
-        Configuration::updateValue('secretKeyForTest', strval(Tools::getValue('secretKeyForTest')));
-        Configuration::updateValue('publicKeyForLive', strval(Tools::getValue('publicKeyForLive')));
-        Configuration::updateValue('secretKeyForLive', strval(Tools::getValue('secretKeyForLive')));
+        Configuration::updateValue('module_status', strval(Tools::getValue('module_status')));
+        Configuration::updateValue('sandbox_status', strval(Tools::getValue('sandbox_status')));
+        Configuration::updateValue('test_public_key', strval(Tools::getValue('test_public_key')));
+        Configuration::updateValue('test_secret_key', strval(Tools::getValue('test_secret_key')));
+        Configuration::updateValue('live_public_key', strval(Tools::getValue('live_public_key')));
+        Configuration::updateValue('live_secret_key', strval(Tools::getValue('live_secret_key')));
         Configuration::updateValue('title', strval(Tools::getValue('title')));
     }
 
-    public function getSubmitActionName()
+    public function getSubmitAction()
     {
-        return $this->submit_action_name;
+        return $this->submit_action;
     }
 }


### PR DESCRIPTION
**1. Objective reason**

Save the configuration that the merchant input on the setting page.

Required pull request: [#1](https://github.com/omise/omise-prestashop/pull/1) and [#5](https://github.com/omise/omise-prestashop/pull/5)

**2. Description of change**
- Move the code that used to display the setting page from class, Omise, to the new class, Form.
- Develop the functions to save and restore the configuration.

**3. Users affected by the change**

All

**4. Impact of the change**

`-`

**5. Priority of change**

Normal

**6. Alternate solution**

`-`
