### PR TITLE
Create omise card token

### DIFF
--- a/omise/form.php
+++ b/omise/form.php
@@ -1,0 +1,145 @@
+<?php
+if (! defined('_PS_VERSION_')) {
+    exit();
+}
+
+class Form extends PaymentModule
+{
+    protected $submit_action_name = 'submitOmiseForm';
+
+    public function generate()
+    {
+        $helper = new HelperForm();
+
+        $helper->submit_action = $this->submit_action_name;
+        $helper->fields_value['module'] = Configuration::get('module');
+        $helper->fields_value['sandbox'] = Configuration::get('sandbox');
+        $helper->fields_value['publicKeyForTest'] = Configuration::get('publicKeyForTest');
+        $helper->fields_value['secretKeyForTest'] = Configuration::get('secretKeyForTest');
+        $helper->fields_value['publicKeyForLive'] = Configuration::get('publicKeyForLive');
+        $helper->fields_value['secretKeyForLive'] = Configuration::get('secretKeyForLive');
+        $helper->fields_value['title'] = Configuration::get('title');
+
+        $fields = $this->getFields();
+
+        return $helper->generateForm($fields);
+    }
+
+    public function getFields()
+    {
+        $fields[0]['form'] = array(
+            'legend' => array(
+                'title' => $this->l('Settings')
+            ),
+            'input' => array(
+                array(
+                    'type' => 'switch',
+                    'label' => $this->l('Enable/Disable'),
+                    'name' => 'module',
+                    'is_bool' => true,
+                    'desc' => $this->l('Enable Omise Payment Module.'),
+                    'values' => array(
+                        array(
+                            'id' => 'module_enabled',
+                            'value' => 1,
+                            'label' => 'Enabled'
+                        ),
+                        array(
+                            'id' => 'module_disabled',
+                            'value' => 0,
+                            'label' => 'Disabled'
+                        )
+                    )
+                ),
+                array(
+                    'type' => 'switch',
+                    'label' => $this->l('Sandbox'),
+                    'name' => 'sandbox',
+                    'is_bool' => true,
+                    'desc' => $this->l('Enabling sandbox means that all your transactions will be in TEST mode.'),
+                    'values' => array(
+                        array(
+                            'id' => 'sandbox_on',
+                            'value' => 1,
+                            'label' => 'Enabled'
+                        ),
+                        array(
+                            'id' => 'sandbox_off',
+                            'value' => 0,
+                            'label' => 'Disabled'
+                        )
+                    )
+                ),
+                array(
+                    'type' => 'text',
+                    'label' => $this->l('Public key for test'),
+                    'name' => 'publicKeyForTest',
+                    'required' => false,
+                    'desc' => $this->l('The "Test" mode public key can be found in Omise Dashboard.')
+                ),
+                array(
+                    'type' => 'text',
+                    'label' => $this->l('Secret key for test'),
+                    'name' => 'secretKeyForTest',
+                    'required' => false,
+                    'desc' => $this->l('The "Test" mode secret key can be found in Omise Dashboard.')
+                ),
+                array(
+                    'type' => 'text',
+                    'label' => $this->l('Public key for live'),
+                    'name' => 'publicKeyForLive',
+                    'required' => false,
+                    'desc' => $this->l('The "Live" mode public key can be found in Omise Dashboard.')
+                ),
+                array(
+                    'type' => 'text',
+                    'label' => $this->l('Secret key for live'),
+                    'name' => 'secretKeyForLive',
+                    'required' => false,
+                    'desc' => $this->l('The "Live" mode secret key can be found in Omise Dashboard.')
+                ),
+                array(
+                    'label' => '<b>' . $this->l('Advance Settings') . '</b>'
+                ),
+                array(
+                    'type' => 'text',
+                    'label' => $this->l('Title'),
+                    'name' => 'title',
+                    'required' => false,
+                    'desc' => $this->l('This controls the title which the user sees during checkout.')
+                )
+            ),
+            'submit' => array(
+                'title' => $this->l('Save'),
+                'class' => 'btn btn-default pull-right'
+            )
+        );
+
+        return $fields;
+    }
+
+    public function isSubmit()
+    {
+        if (Tools::isSubmit($this->submit_action_name)) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    public function save()
+    {
+        Configuration::updateValue('module', strval(Tools::getValue('module')));
+        Configuration::updateValue('sandbox', strval(Tools::getValue('sandbox')));
+        Configuration::updateValue('publicKeyForTest', strval(Tools::getValue('publicKeyForTest')));
+        Configuration::updateValue('secretKeyForTest', strval(Tools::getValue('secretKeyForTest')));
+        Configuration::updateValue('publicKeyForLive', strval(Tools::getValue('publicKeyForLive')));
+        Configuration::updateValue('secretKeyForLive', strval(Tools::getValue('secretKeyForLive')));
+        Configuration::updateValue('title', strval(Tools::getValue('title')));
+    }
+
+    public function getSubmitActionName()
+    {
+        return $this->submit_action_name;
+    }
+}

--- a/omise/omise.php
+++ b/omise/omise.php
@@ -1,6 +1,9 @@
 <?php
-if (! defined('_PS_VERSION_'))
+if (! defined('_PS_VERSION_')) {
     exit();
+}
+
+require_once 'form.php';
 
 class Omise extends PaymentModule
 {
@@ -25,6 +28,8 @@ class Omise extends PaymentModule
      */
     const MODULE_VERSION = '1.6.0.0';
 
+    protected $form;
+
     public function __construct()
     {
         $this->name                   = self::MODULE_NAME;
@@ -39,101 +44,31 @@ class Omise extends PaymentModule
 
         $this->displayName            = self::MODULE_DISPLAY_NAME;
         $this->confirmUninstall       = $this->l('Are you sure you want to uninstall ' . self::MODULE_DISPLAY_NAME . ' module?');
+
+        $this->setForm(new Form());
     }
 
     public function getContent()
     {
-        $fields_form[0]['form'] = array(
-            'legend' => array(
-                'title' => $this->l('Settings')
-            ),
-            'input' => array(
-                array(
-                    'type' => 'switch',
-                    'label' => $this->l('Enable/Disable'),
-                    'name' => 'module',
-                    'is_bool' => true,
-                    'desc' => $this->l('Enable Omise Payment Module.'),
-                    'values' => array(
-                        array(
-                            'id' => 'module_enabled',
-                            'value' => 1,
-                            'label' => 'Enabled'
-                        ),
-                        array(
-                            'id' => 'module_disabled',
-                            'value' => 0,
-                            'label' => 'Disabled'
-                        )
-                    )
-                ),
-                array(
-                    'type' => 'switch',
-                    'label' => $this->l('Sandbox'),
-                    'name' => 'sandbox',
-                    'is_bool' => true,
-                    'desc' => $this->l('Enabling sandbox means that all your transactions will be in TEST mode.'),
-                    'values' => array(
-                        array(
-                            'id' => 'sandbox_on',
-                            'value' => 1,
-                            'label' => 'Enabled'
-                        ),
-                        array(
-                            'id' => 'sandbox_off',
-                            'value' => 0,
-                            'label' => 'Disabled'
-                        )
-                    )
-                ),
-                array(
-                    'type' => 'text',
-                    'label' => $this->l('Public key for test'),
-                    'name' => 'publicKeyForTest',
-                    'required' => false,
-                    'desc' => 'The "Test" mode public key can be found in Omise Dashboard.'
-                ),
-                array(
-                    'type' => 'text',
-                    'label' => $this->l('Secret key for test'),
-                    'name' => 'secretKeyForTest',
-                    'required' => false,
-                    'desc' => 'The "Test" mode secret key can be found in Omise Dashboard.'
-                ),
-                array(
-                    'type' => 'text',
-                    'label' => $this->l('Public key for live'),
-                    'name' => 'publicKeyForLive',
-                    'required' => false,
-                    'desc' => 'The "Live" mode public key can be found in Omise Dashboard.'
-                ),
-                array(
-                    'type' => 'text',
-                    'label' => $this->l('Secret key for live'),
-                    'name' => 'secretKeyForLive',
-                    'required' => false,
-                    'desc' => 'The "Live" mode secret key can be found in Omise Dashboard.'
-                ),
-                array(
-                    'label' => '<b>Advance Settings</b>'
-                ),
-                array(
-                    'type' => 'text',
-                    'label' => $this->l('Title'),
-                    'name' => 'title',
-                    'required' => false,
-                    'desc' => 'This controls the title which the user sees during checkout.'
-                )
-            ),
-            'submit' => array(
-                'title' => $this->l('Save'),
-                'class' => 'btn btn-default pull-right'
-            )
-        );
+        $content = '';
 
-        $helper = new HelperForm();
-        $helper->submit_action = 'submit' . $this->name;
+        if ($this->form->isSubmit()) {
+            $this->form->save();
+            $content .= $this->displayConfirmation($this->l('Settings updated'));
+        }
 
-        return $helper->generateForm($fields_form);
+        $content .= $this->form->generate();
+
+        return $content;
+    }
+
+    public function getForm()
+    {
+        return $this->form;
+    }
+
+    public function setForm($form)
+    {
+        $this->form = $form;
     }
 }

--- a/omise/omise.php
+++ b/omise/omise.php
@@ -68,6 +68,8 @@ class Omise extends PaymentModule
             return;
         }
 
+        $this->smarty->assign('omise_title', $this->setting->getTitle());
+
         return $this->display(__FILE__, 'payment.tpl');
     }
 
@@ -79,5 +81,10 @@ class Omise extends PaymentModule
     public function setSetting($setting)
     {
         $this->setting = $setting;
+    }
+
+    public function setSmarty($smarty)
+    {
+        $this->smarty = $smarty;
     }
 }

--- a/omise/omise.php
+++ b/omise/omise.php
@@ -40,4 +40,100 @@ class Omise extends PaymentModule
         $this->displayName            = self::MODULE_DISPLAY_NAME;
         $this->confirmUninstall       = $this->l('Are you sure you want to uninstall ' . self::MODULE_DISPLAY_NAME . ' module?');
     }
+
+    public function getContent()
+    {
+        $fields_form[0]['form'] = array(
+            'legend' => array(
+                'title' => $this->l('Settings')
+            ),
+            'input' => array(
+                array(
+                    'type' => 'switch',
+                    'label' => $this->l('Enable/Disable'),
+                    'name' => 'module',
+                    'is_bool' => true,
+                    'desc' => $this->l('Enable Omise Payment Module.'),
+                    'values' => array(
+                        array(
+                            'id' => 'module_enabled',
+                            'value' => 1,
+                            'label' => 'Enabled'
+                        ),
+                        array(
+                            'id' => 'module_disabled',
+                            'value' => 0,
+                            'label' => 'Disabled'
+                        )
+                    )
+                ),
+                array(
+                    'type' => 'switch',
+                    'label' => $this->l('Sandbox'),
+                    'name' => 'sandbox',
+                    'is_bool' => true,
+                    'desc' => $this->l('Enabling sandbox means that all your transactions will be in TEST mode.'),
+                    'values' => array(
+                        array(
+                            'id' => 'sandbox_on',
+                            'value' => 1,
+                            'label' => 'Enabled'
+                        ),
+                        array(
+                            'id' => 'sandbox_off',
+                            'value' => 0,
+                            'label' => 'Disabled'
+                        )
+                    )
+                ),
+                array(
+                    'type' => 'text',
+                    'label' => $this->l('Public key for test'),
+                    'name' => 'publicKeyForTest',
+                    'required' => false,
+                    'desc' => 'The "Test" mode public key can be found in Omise Dashboard.'
+                ),
+                array(
+                    'type' => 'text',
+                    'label' => $this->l('Secret key for test'),
+                    'name' => 'secretKeyForTest',
+                    'required' => false,
+                    'desc' => 'The "Test" mode secret key can be found in Omise Dashboard.'
+                ),
+                array(
+                    'type' => 'text',
+                    'label' => $this->l('Public key for live'),
+                    'name' => 'publicKeyForLive',
+                    'required' => false,
+                    'desc' => 'The "Live" mode public key can be found in Omise Dashboard.'
+                ),
+                array(
+                    'type' => 'text',
+                    'label' => $this->l('Secret key for live'),
+                    'name' => 'secretKeyForLive',
+                    'required' => false,
+                    'desc' => 'The "Live" mode secret key can be found in Omise Dashboard.'
+                ),
+                array(
+                    'label' => '<b>Advance Settings</b>'
+                ),
+                array(
+                    'type' => 'text',
+                    'label' => $this->l('Title'),
+                    'name' => 'title',
+                    'required' => false,
+                    'desc' => 'This controls the title which the user sees during checkout.'
+                )
+            ),
+            'submit' => array(
+                'title' => $this->l('Save'),
+                'class' => 'btn btn-default pull-right'
+            )
+        );
+
+        $helper = new HelperForm();
+        $helper->submit_action = 'submit' . $this->name;
+
+        return $helper->generateForm($fields_form);
+    }
 }

--- a/omise/omise.php
+++ b/omise/omise.php
@@ -62,6 +62,15 @@ class Omise extends PaymentModule
         return $content;
     }
 
+    public function hookPayment($params)
+    {
+        if ($this->active == false || $this->setting->isModuleEnabled() == false) {
+            return;
+        }
+
+        return $this->display(__FILE__, 'payment.tpl');
+    }
+
     public function getSetting()
     {
         return $this->setting;

--- a/omise/omise.php
+++ b/omise/omise.php
@@ -68,6 +68,7 @@ class Omise extends PaymentModule
             return;
         }
 
+        $this->smarty->assign('omise_public_key', $this->setting->getPublicKey());
         $this->smarty->assign('omise_title', $this->setting->getTitle());
 
         return $this->display(__FILE__, 'payment.tpl');

--- a/omise/omise.php
+++ b/omise/omise.php
@@ -3,7 +3,7 @@ if (! defined('_PS_VERSION_')) {
     exit();
 }
 
-require_once 'form.php';
+require_once 'setting.php';
 
 class Omise extends PaymentModule
 {
@@ -28,7 +28,7 @@ class Omise extends PaymentModule
      */
     const MODULE_VERSION = '1.6.0.0';
 
-    protected $form;
+    protected $setting;
 
     public function __construct()
     {
@@ -45,30 +45,30 @@ class Omise extends PaymentModule
         $this->displayName            = self::MODULE_DISPLAY_NAME;
         $this->confirmUninstall       = $this->l('Are you sure you want to uninstall ' . self::MODULE_DISPLAY_NAME . ' module?');
 
-        $this->setForm(new Form());
+        $this->setSetting(new Setting());
     }
 
     public function getContent()
     {
         $content = '';
 
-        if ($this->form->isSubmit()) {
-            $this->form->save();
+        if ($this->setting->isSubmit()) {
+            $this->setting->save();
             $content .= $this->displayConfirmation($this->l('Settings updated'));
         }
 
-        $content .= $this->form->generate();
+        $content .= $this->setting->generateForm();
 
         return $content;
     }
 
-    public function getForm()
+    public function getSetting()
     {
-        return $this->form;
+        return $this->setting;
     }
 
-    public function setForm($form)
+    public function setSetting($setting)
     {
-        $this->form = $form;
+        $this->setting = $setting;
     }
 }

--- a/omise/setting.php
+++ b/omise/setting.php
@@ -132,9 +132,9 @@ class Setting extends PaymentModule
     {
         if (Tools::isSubmit($this->getSubmitAction())) {
             return true;
-        } else {
-            return false;
         }
+
+        return false;
     }
 
     public function save()

--- a/omise/setting.php
+++ b/omise/setting.php
@@ -3,21 +3,21 @@ if (! defined('_PS_VERSION_')) {
     exit();
 }
 
-class Form extends PaymentModule
+class Setting extends PaymentModule
 {
-    protected $submit_action_name = 'submitOmiseForm';
+    protected $submit_action = 'omise_save_setting';
 
-    public function generate()
+    public function generateForm()
     {
         $helper = new HelperForm();
 
-        $helper->submit_action = $this->submit_action_name;
-        $helper->fields_value['module'] = Configuration::get('module');
-        $helper->fields_value['sandbox'] = Configuration::get('sandbox');
-        $helper->fields_value['publicKeyForTest'] = Configuration::get('publicKeyForTest');
-        $helper->fields_value['secretKeyForTest'] = Configuration::get('secretKeyForTest');
-        $helper->fields_value['publicKeyForLive'] = Configuration::get('publicKeyForLive');
-        $helper->fields_value['secretKeyForLive'] = Configuration::get('secretKeyForLive');
+        $helper->submit_action = $this->getSubmitAction();
+        $helper->fields_value['module_status'] = Configuration::get('module_status');
+        $helper->fields_value['sandbox_status'] = Configuration::get('sandbox_status');
+        $helper->fields_value['test_public_key'] = Configuration::get('test_public_key');
+        $helper->fields_value['test_secret_key'] = Configuration::get('test_secret_key');
+        $helper->fields_value['live_public_key'] = Configuration::get('live_public_key');
+        $helper->fields_value['live_secret_key'] = Configuration::get('live_secret_key');
         $helper->fields_value['title'] = Configuration::get('title');
 
         $fields = $this->getFields();
@@ -32,76 +32,76 @@ class Form extends PaymentModule
                 'title' => $this->l('Settings')
             ),
             'input' => array(
-                array(
+                'module_status' => array(
                     'type' => 'switch',
                     'label' => $this->l('Enable/Disable'),
-                    'name' => 'module',
+                    'name' => 'module_status',
                     'is_bool' => true,
                     'desc' => $this->l('Enable Omise Payment Module.'),
                     'values' => array(
                         array(
-                            'id' => 'module_enabled',
+                            'id' => 'module_status_enabled',
                             'value' => 1,
                             'label' => 'Enabled'
                         ),
                         array(
-                            'id' => 'module_disabled',
+                            'id' => 'module_status_disabled',
                             'value' => 0,
                             'label' => 'Disabled'
                         )
                     )
                 ),
-                array(
+                'sandbox_status' => array(
                     'type' => 'switch',
                     'label' => $this->l('Sandbox'),
-                    'name' => 'sandbox',
+                    'name' => 'sandbox_status',
                     'is_bool' => true,
                     'desc' => $this->l('Enabling sandbox means that all your transactions will be in TEST mode.'),
                     'values' => array(
                         array(
-                            'id' => 'sandbox_on',
+                            'id' => 'sandbox_status_enabled',
                             'value' => 1,
                             'label' => 'Enabled'
                         ),
                         array(
-                            'id' => 'sandbox_off',
+                            'id' => 'sandbox_status_disabled',
                             'value' => 0,
                             'label' => 'Disabled'
                         )
                     )
                 ),
-                array(
+                'test_public_key' => array(
                     'type' => 'text',
                     'label' => $this->l('Public key for test'),
-                    'name' => 'publicKeyForTest',
+                    'name' => 'test_public_key',
                     'required' => false,
                     'desc' => $this->l('The "Test" mode public key can be found in Omise Dashboard.')
                 ),
-                array(
+                'test_secret_key' => array(
                     'type' => 'text',
                     'label' => $this->l('Secret key for test'),
-                    'name' => 'secretKeyForTest',
+                    'name' => 'test_secret_key',
                     'required' => false,
                     'desc' => $this->l('The "Test" mode secret key can be found in Omise Dashboard.')
                 ),
-                array(
+                'live_public_key' => array(
                     'type' => 'text',
                     'label' => $this->l('Public key for live'),
-                    'name' => 'publicKeyForLive',
+                    'name' => 'live_public_key',
                     'required' => false,
                     'desc' => $this->l('The "Live" mode public key can be found in Omise Dashboard.')
                 ),
-                array(
+                'live_secret_key' => array(
                     'type' => 'text',
                     'label' => $this->l('Secret key for live'),
-                    'name' => 'secretKeyForLive',
+                    'name' => 'live_secret_key',
                     'required' => false,
                     'desc' => $this->l('The "Live" mode secret key can be found in Omise Dashboard.')
                 ),
-                array(
+                'advance_settings' => array(
                     'label' => '<b>' . $this->l('Advance Settings') . '</b>'
                 ),
-                array(
+                'title' => array(
                     'type' => 'text',
                     'label' => $this->l('Title'),
                     'name' => 'title',
@@ -120,7 +120,7 @@ class Form extends PaymentModule
 
     public function isSubmit()
     {
-        if (Tools::isSubmit($this->submit_action_name)) {
+        if (Tools::isSubmit($this->getSubmitAction())) {
             return true;
         } else {
             return false;
@@ -129,17 +129,17 @@ class Form extends PaymentModule
 
     public function save()
     {
-        Configuration::updateValue('module', strval(Tools::getValue('module')));
-        Configuration::updateValue('sandbox', strval(Tools::getValue('sandbox')));
-        Configuration::updateValue('publicKeyForTest', strval(Tools::getValue('publicKeyForTest')));
-        Configuration::updateValue('secretKeyForTest', strval(Tools::getValue('secretKeyForTest')));
-        Configuration::updateValue('publicKeyForLive', strval(Tools::getValue('publicKeyForLive')));
-        Configuration::updateValue('secretKeyForLive', strval(Tools::getValue('secretKeyForLive')));
+        Configuration::updateValue('module_status', strval(Tools::getValue('module_status')));
+        Configuration::updateValue('sandbox_status', strval(Tools::getValue('sandbox_status')));
+        Configuration::updateValue('test_public_key', strval(Tools::getValue('test_public_key')));
+        Configuration::updateValue('test_secret_key', strval(Tools::getValue('test_secret_key')));
+        Configuration::updateValue('live_public_key', strval(Tools::getValue('live_public_key')));
+        Configuration::updateValue('live_secret_key', strval(Tools::getValue('live_secret_key')));
         Configuration::updateValue('title', strval(Tools::getValue('title')));
     }
 
-    public function getSubmitActionName()
+    public function getSubmitAction()
     {
-        return $this->submit_action_name;
+        return $this->submit_action;
     }
 }

--- a/omise/setting.php
+++ b/omise/setting.php
@@ -125,7 +125,11 @@ class Setting extends PaymentModule
 
     public function isModuleEnabled()
     {
-        return Configuration::get('module_status');
+        if (Configuration::get('module_status')) {
+            return true;
+        }
+
+        return false;
     }
 
     public function isSubmit()

--- a/omise/setting.php
+++ b/omise/setting.php
@@ -118,6 +118,11 @@ class Setting extends PaymentModule
         return $fields;
     }
 
+    public function isModuleEnabled()
+    {
+        return Configuration::get('module_status');
+    }
+
     public function isSubmit()
     {
         if (Tools::isSubmit($this->getSubmitAction())) {

--- a/omise/setting.php
+++ b/omise/setting.php
@@ -118,6 +118,20 @@ class Setting extends PaymentModule
         return $fields;
     }
 
+    public function getPublicKey()
+    {
+        if ($this->isSandboxEnabled()) {
+            return Configuration::get('test_public_key');
+        }
+
+        return Configuration::get('live_public_key');
+    }
+
+    public function getSubmitAction()
+    {
+        return $this->submit_action;
+    }
+
     public function getTitle()
     {
         return Configuration::get('title');
@@ -126,6 +140,15 @@ class Setting extends PaymentModule
     public function isModuleEnabled()
     {
         if (Configuration::get('module_status')) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public function isSandboxEnabled()
+    {
+        if (Configuration::get('sandbox_status')) {
             return true;
         }
 
@@ -150,10 +173,5 @@ class Setting extends PaymentModule
         Configuration::updateValue('live_public_key', strval(Tools::getValue('live_public_key')));
         Configuration::updateValue('live_secret_key', strval(Tools::getValue('live_secret_key')));
         Configuration::updateValue('title', strval(Tools::getValue('title')));
-    }
-
-    public function getSubmitAction()
-    {
-        return $this->submit_action;
     }
 }

--- a/omise/setting.php
+++ b/omise/setting.php
@@ -118,6 +118,11 @@ class Setting extends PaymentModule
         return $fields;
     }
 
+    public function getTitle()
+    {
+        return Configuration::get('title');
+    }
+
     public function isModuleEnabled()
     {
         return Configuration::get('module_status');

--- a/omise/views/templates/hook/payment.tpl
+++ b/omise/views/templates/hook/payment.tpl
@@ -65,10 +65,10 @@ const omiseCheckout = function omiseCheckout() {
   };
 
   Omise.setPublicKey('{$omise_public_key}');
-  Omise.createToken('card', card, omiseCreateTokenCallBack);
+  Omise.createToken('card', card, omiseCreateTokenCallback);
 }
 
-const omiseCreateTokenCallBack = function omiseCreateTokenCallBack(statusCode, response) {
+const omiseCreateTokenCallback = function omiseCreateTokenCallback(statusCode, response) {
   if (statusCode === 200) {
     document.getElementById('omise_card_token').value = response.id;
   } else {

--- a/omise/views/templates/hook/payment.tpl
+++ b/omise/views/templates/hook/payment.tpl
@@ -2,49 +2,49 @@
 	<div class="col-xs-12">
 		<p class="payment_module">
 			<div class="box">
-        		<div class="row">
-        			<h3>Omise Payment Gateway</h3>
-        			<div class="col-sm-3">
-        				<form>
-        					<div class="row">
-        						<div class="form-group col-sm-12">
-        							<label for="omise_card_number">{l s='Card number' mod='omise'}</label>
-        							<input type="text" class="form-control" id="omise_card_number" placeholder="{l s='Card number' mod='omise'}" />
-        						</div>
-        					</div>
-        					<div class="row">
-        						<div class="form-group col-sm-12">
-        							<label for="omise_card_holder_name">{l s='Card holder name' mod='omise'}</label>
-        							<input type="text" class="form-control" id="omise_card_holder_name" placeholder="{l s='Card holder name' mod='omise'}" />
-        						</div>
-        					</div>
-        					<div class="row">
-        						<div class="col-sm-6">
-        							<div class="form-group">
-        								<label for="omise_card_expiration_month">{l s='Expiration month' mod='omise'}</label>
-        								<input type="text" class="form-control" id="omise_card_expiration_month" placeholder="{l s='MM' mod='omise'}" />
-        							</div>
-        						</div>
-        						<div class="col-sm-6 pull-right">
-        							<div class="form-group">
-        								<label for="omise_card_expiration_year">{l s='Expiration year' mod='omise'}</label>
-        								<input type="text" class="form-control" id="omise_card_expiration_year" placeholder="{l s='YYYY' mod='omise'}" />
-        							</div>
-        						</div>
-        					</div>
-        					<div class="row">
-        						<div class="col-sm-6">
-        							<div class="form-group">
-        								<label for="security_code">{l s='Security code' mod='omise'}</label>
-        								<input type="password" class="form-control" id="security_code" placeholder="{l s='Security code' mod='omise'}" />
-        							</div>
-        						</div>
-        					</div>
-        					<button type="submit" class="button btn btn-default">{l s='Checkout' mod='omise'}</button>
-        				</form>
-        			</div>
-        		</div>
-    		</div>
+				<div class="row">
+					<div class="col-sm-4">
+						<h3>{$omise_title}</h3>
+						<form>
+							<div class="row">
+								<div class="form-group col-sm-12">
+									<label for="omise_card_number" class="required">&nbsp;{l s='Card number' mod='omise'}</label>
+									<input type="text" class="form-control" id="omise_card_number" placeholder="{l s='Card number' mod='omise'}" />
+								</div>
+							</div>
+							<div class="row">
+								<div class="form-group col-sm-12">
+									<label for="omise_card_holder_name" class="required">&nbsp;{l s='Card holder name' mod='omise'}</label>
+									<input type="text" class="form-control" id="omise_card_holder_name" placeholder="{l s='Card holder name' mod='omise'}" />
+								</div>
+							</div>
+							<div class="row">
+								<div class="col-sm-6">
+									<div class="form-group">
+										<label for="omise_card_expiration_month" class="required">&nbsp;{l s='Expiration month' mod='omise'}</label>
+										<input type="text" class="form-control" id="omise_card_expiration_month" placeholder="{l s='MM' mod='omise'}" />
+									</div>
+								</div>
+								<div class="col-sm-6 pull-right">
+									<div class="form-group">
+										<label for="omise_card_expiration_year" class="required">&nbsp;{l s='Expiration year' mod='omise'}</label>
+										<input type="text" class="form-control" id="omise_card_expiration_year" placeholder="{l s='YYYY' mod='omise'}" />
+									</div>
+								</div>
+							</div>
+							<div class="row">
+								<div class="col-sm-6">
+									<div class="form-group">
+										<label for="omise_card_security_code" class="required">&nbsp;{l s='Security code' mod='omise'}</label>
+										<input type="password" class="form-control" id="omise_card_security_code" placeholder="{l s='Security code' mod='omise'}" />
+									</div>
+								</div>
+							</div>
+							<button class="button btn btn-default">{l s='Checkout' mod='omise'}</button>
+						</form>
+					</div>
+				</div>
+			</div>
 		</p>
 	</div>
 </div>

--- a/omise/views/templates/hook/payment.tpl
+++ b/omise/views/templates/hook/payment.tpl
@@ -54,7 +54,7 @@
 
 <script>
   const omiseCheckout = function omiseCheckout() {
-    document.getElementById('omise_checkout').disabled = true;
+    omiseLockCheckoutForm();
 
     const card = {
       name: document.getElementById('omise_card_holder_name').value,
@@ -73,7 +73,27 @@
       document.getElementById('omise_card_token').value = response.id;
     } else {
       alert(response.message);
-      document.getElementById('omise_checkout').disabled = false;
+      omiseUnlockCheckoutForm();
     }
+  };
+
+  const omiseLockCheckoutForm = function omiseLockCheckoutForm() {
+    document.getElementById('omise_card_holder_name').disabled = true;
+    document.getElementById('omise_card_number').disabled = true;
+    document.getElementById('omise_card_expiration_month').disabled = true;
+    document.getElementById('omise_card_expiration_year').disabled = true;
+    document.getElementById('omise_card_security_code').disabled = true;
+    document.getElementById('omise_checkout').disabled = true;
+    document.getElementById("omise_checkout").innerHTML = '{l s='Processing' mod='omise'}';
+  };
+
+  const omiseUnlockCheckoutForm = function omiseUnlockCheckoutForm() {
+    document.getElementById('omise_card_holder_name').disabled = false;
+    document.getElementById('omise_card_number').disabled = false;
+    document.getElementById('omise_card_expiration_month').disabled = false;
+    document.getElementById('omise_card_expiration_year').disabled = false;
+    document.getElementById('omise_card_security_code').disabled = false;
+    document.getElementById('omise_checkout').disabled = false;
+    document.getElementById("omise_checkout").innerHTML = '{l s='Checkout' mod='omise'}';
   };
 </script>

--- a/omise/views/templates/hook/payment.tpl
+++ b/omise/views/templates/hook/payment.tpl
@@ -1,77 +1,79 @@
 <div class="row">
-	<div class="col-xs-12">
-		<p class="payment_module">
-			<div class="box">
-				<div class="row">
-					<div class="col-sm-4">
-						<h3>{$omise_title}</h3>
-						<form>
-							<input type="hidden" id="omise_card_token" name="omise_card_token" />
-							<div class="row">
-								<div class="form-group col-sm-12">
-									<label for="omise_card_number" class="required">&nbsp;{l s='Card number' mod='omise'}</label>
-									<input type="text" class="form-control" id="omise_card_number" placeholder="{l s='Card number' mod='omise'}" />
-								</div>
-							</div>
-							<div class="row">
-								<div class="form-group col-sm-12">
-									<label for="omise_card_holder_name" class="required">&nbsp;{l s='Card holder name' mod='omise'}</label>
-									<input type="text" class="form-control" id="omise_card_holder_name" placeholder="{l s='Card holder name' mod='omise'}" />
-								</div>
-							</div>
-							<div class="row">
-								<div class="col-sm-6">
-									<div class="form-group">
-										<label for="omise_card_expiration_month" class="required">&nbsp;{l s='Expiration month' mod='omise'}</label>
-										<input type="text" class="form-control" id="omise_card_expiration_month" placeholder="{l s='MM' mod='omise'}" />
-									</div>
-								</div>
-								<div class="col-sm-6 pull-right">
-									<div class="form-group">
-										<label for="omise_card_expiration_year" class="required">&nbsp;{l s='Expiration year' mod='omise'}</label>
-										<input type="text" class="form-control" id="omise_card_expiration_year" placeholder="{l s='YYYY' mod='omise'}" />
-									</div>
-								</div>
-							</div>
-							<div class="row">
-								<div class="col-sm-6">
-									<div class="form-group">
-										<label for="omise_card_security_code" class="required">&nbsp;{l s='Security code' mod='omise'}</label>
-										<input type="password" class="form-control" id="omise_card_security_code" placeholder="{l s='Security code' mod='omise'}" />
-									</div>
-								</div>
-							</div>
-							<button id="omise_checkout" class="button btn btn-default" onclick="omiseCheckout(); return false;">{l s='Checkout' mod='omise'}</button>
-						</form>
-					</div>
-				</div>
-			</div>
-		</p>
-	</div>
+  <div class="col-xs-12">
+    <p class="payment_module">
+      <div class="box">
+        <div class="row">
+          <div class="col-sm-4">
+            <h3>{$omise_title}</h3>
+              <form>
+                <input id="omise_card_token" name="omise_card_token" type="hidden">
+                <div class="row">
+                  <div class="form-group col-sm-12">
+                    <label class="required" for="omise_card_number">&nbsp;{l s='Card number' mod='omise'}</label>
+                    <input class="form-control" id="omise_card_number" type="text" placeholder="{l s='Card number' mod='omise'}">
+                  </div>
+                </div>
+                <div class="row">
+                  <div class="form-group col-sm-12">
+                      <label class="required" for="omise_card_holder_name">&nbsp;{l s='Card holder name' mod='omise'}</label>
+                      <input class="form-control" id="omise_card_holder_name" type="text" placeholder="{l s='Card holder name' mod='omise'}">
+                    </div>
+                </div>
+                <div class="row">
+                  <div class="col-sm-6">
+                    <div class="form-group">
+                      <label class="required" for="omise_card_expiration_month">&nbsp;{l s='Expiration month' mod='omise'}</label>
+                      <input class="form-control" id="omise_card_expiration_month" type="text" placeholder="{l s='MM' mod='omise'}">
+                    </div>
+                  </div>
+                  <div class="col-sm-6 pull-right">
+                    <div class="form-group">
+                      <label class="required" for="omise_card_expiration_year">&nbsp;{l s='Expiration year' mod='omise'}</label>
+                      <input class="form-control" id="omise_card_expiration_year" type="text" placeholder="{l s='YYYY' mod='omise'}">
+                    </div>
+                  </div>
+                </div>
+                <div class="row">
+                  <div class="col-sm-6">
+                    <div class="form-group">
+                      <label class="required" for="omise_card_security_code">&nbsp;{l s='Security code' mod='omise'}</label>
+                      <input class="form-control" id="omise_card_security_code" type="password" placeholder="{l s='Security code' mod='omise'}">
+                    </div>
+                  </div>
+                </div>
+                <button class="button btn btn-default" id="omise_checkout" onclick="omiseCheckout(); return false;">{l s='Checkout' mod='omise'}</button>
+            </form>
+          </div>
+        </div>
+      </div>
+    </p>
+  </div>
 </div>
 
-<script type="text/javascript" src="https://cdn.omise.co/omise.js.gz"></script>
+<script src="https://cdn.omise.co/omise.js.gz"></script>
 
-<script type="text/javascript">
-function omiseCheckout() {
-	document.getElementById("omise_checkout").disabled = true;
+<script>
+const omiseCheckout = function omiseCheckout() {
+  document.getElementById('omise_checkout').disabled = true;
 
-	const card = {
-		name: document.getElementById("omise_card_holder_name").value,
-		number: document.getElementById("omise_card_number").value,
-		expiration_month: document.getElementById("omise_card_expiration_month").value,
-		expiration_year: document.getElementById("omise_card_expiration_year").value,
-		security_code: document.getElementById("omise_card_security_code").value
-	};
+  const card = {
+    name: document.getElementById('omise_card_holder_name').value,
+    number: document.getElementById('omise_card_number').value,
+    expiration_month: document.getElementById('omise_card_expiration_month').value,
+    expiration_year: document.getElementById('omise_card_expiration_year').value,
+    security_code: document.getElementById('omise_card_security_code').value,
+  };
 
-	Omise.setPublicKey("{$omise_public_key}");
-	Omise.createToken("card", card, function (statusCode, response) {
-		if (statusCode == 200) {
-			document.getElementById("omise_card_token").value = response.id;
-		} else {
-			alert(response.message);
-			document.getElementById("omise_checkout").disabled = false;
-		}
-	});
+  Omise.setPublicKey('{$omise_public_key}');
+  Omise.createToken('card', card, omiseCreateTokenCallBack);
+}
+
+const omiseCreateTokenCallBack = function omiseCreateTokenCallBack(statusCode, response) {
+  if (statusCode === 200) {
+    document.getElementById('omise_card_token').value = response.id;
+  } else {
+    alert(response.message);
+    document.getElementById("omise_checkout").disabled = false;
+  }
 }
 </script>

--- a/omise/views/templates/hook/payment.tpl
+++ b/omise/views/templates/hook/payment.tpl
@@ -36,7 +36,7 @@
         						<div class="col-sm-4">
         							<div class="form-group">
         								<label for="security_code">{l s='CVC' mod='omise'}</label>
-        								<input type="text" class="form-control" id="security_code" placeholder="{l s='CVC' mod='omise'}" />
+        								<input type="password" class="form-control" id="security_code" placeholder="{l s='CVC' mod='omise'}" />
         							</div>
         						</div>
         					</div>

--- a/omise/views/templates/hook/payment.tpl
+++ b/omise/views/templates/hook/payment.tpl
@@ -35,8 +35,8 @@
         					<div class="row">
         						<div class="col-sm-4">
         							<div class="form-group">
-        								<label for="security_code">{l s='CVC' mod='omise'}</label>
-        								<input type="password" class="form-control" id="security_code" placeholder="{l s='CVC' mod='omise'}" />
+        								<label for="security_code">{l s='Security code' mod='omise'}</label>
+        								<input type="password" class="form-control" id="security_code" placeholder="{l s='Security code' mod='omise'}" />
         							</div>
         						</div>
         					</div>

--- a/omise/views/templates/hook/payment.tpl
+++ b/omise/views/templates/hook/payment.tpl
@@ -53,27 +53,27 @@
 <script src="https://cdn.omise.co/omise.js.gz"></script>
 
 <script>
-const omiseCheckout = function omiseCheckout() {
-  document.getElementById('omise_checkout').disabled = true;
+  const omiseCheckout = function omiseCheckout() {
+    document.getElementById('omise_checkout').disabled = true;
 
-  const card = {
-    name: document.getElementById('omise_card_holder_name').value,
-    number: document.getElementById('omise_card_number').value,
-    expiration_month: document.getElementById('omise_card_expiration_month').value,
-    expiration_year: document.getElementById('omise_card_expiration_year').value,
-    security_code: document.getElementById('omise_card_security_code').value,
-  };
+    const card = {
+      name: document.getElementById('omise_card_holder_name').value,
+      number: document.getElementById('omise_card_number').value,
+      expiration_month: document.getElementById('omise_card_expiration_month').value,
+      expiration_year: document.getElementById('omise_card_expiration_year').value,
+      security_code: document.getElementById('omise_card_security_code').value,
+    };
 
-  Omise.setPublicKey('{$omise_public_key}');
-  Omise.createToken('card', card, omiseCreateTokenCallback);
-}
-
-const omiseCreateTokenCallback = function omiseCreateTokenCallback(statusCode, response) {
-  if (statusCode === 200) {
-    document.getElementById('omise_card_token').value = response.id;
-  } else {
-    alert(response.message);
-    document.getElementById('omise_checkout').disabled = false;
+    Omise.setPublicKey('{$omise_public_key}');
+    Omise.createToken('card', card, omiseCreateTokenCallback);
   }
-};
+
+  const omiseCreateTokenCallback = function omiseCreateTokenCallback(statusCode, response) {
+    if (statusCode === 200) {
+      document.getElementById('omise_card_token').value = response.id;
+    } else {
+      alert(response.message);
+      document.getElementById('omise_checkout').disabled = false;
+    }
+  };
 </script>

--- a/omise/views/templates/hook/payment.tpl
+++ b/omise/views/templates/hook/payment.tpl
@@ -73,7 +73,7 @@ const omiseCreateTokenCallback = function omiseCreateTokenCallback(statusCode, r
     document.getElementById('omise_card_token').value = response.id;
   } else {
     alert(response.message);
-    document.getElementById("omise_checkout").disabled = false;
+    document.getElementById('omise_checkout').disabled = false;
   }
 };
 </script>

--- a/omise/views/templates/hook/payment.tpl
+++ b/omise/views/templates/hook/payment.tpl
@@ -54,6 +54,11 @@
 
 <script>
   const omiseCheckout = function omiseCheckout() {
+    if (typeof Omise === 'undefined') {
+      alert('{l s='Unable to process the payment, loading the external card processing library is failed. Please contact the merchant.' mod='omise'}');
+      return false;
+    }
+
     omiseLockCheckoutForm();
 
     const card = {

--- a/omise/views/templates/hook/payment.tpl
+++ b/omise/views/templates/hook/payment.tpl
@@ -1,0 +1,50 @@
+<div class="row">
+	<div class="col-xs-12">
+		<p class="payment_module">
+			<div class="box">
+        		<div class="row">
+        			<h3>Omise Payment Gateway</h3>
+        			<div class="col-sm-3">
+        				<form>
+        					<div class="row">
+        						<div class="form-group col-sm-12">
+        							<label for="omise_card_number">{l s='Card number' mod='omise'}</label>
+        							<input type="text" class="form-control" id="omise_card_number" placeholder="{l s='Card number' mod='omise'}" />
+        						</div>
+        					</div>
+        					<div class="row">
+        						<div class="form-group col-sm-12">
+        							<label for="omise_card_holder_name">{l s='Card holder name' mod='omise'}</label>
+        							<input type="text" class="form-control" id="omise_card_holder_name" placeholder="{l s='Card holder name' mod='omise'}" />
+        						</div>
+        					</div>
+        					<div class="row">
+        						<div class="col-sm-6">
+        							<div class="form-group">
+        								<label for="omise_card_expiration_month">{l s='Expiration month' mod='omise'}</label>
+        								<input type="text" class="form-control" id="omise_card_expiration_month" placeholder="{l s='MM' mod='omise'}" />
+        							</div>
+        						</div>
+        						<div class="col-sm-6 pull-right">
+        							<div class="form-group">
+        								<label for="omise_card_expiration_year">{l s='Expiration year' mod='omise'}</label>
+        								<input type="text" class="form-control" id="omise_card_expiration_year" placeholder="{l s='YYYY' mod='omise'}" />
+        							</div>
+        						</div>
+        					</div>
+        					<div class="row">
+        						<div class="col-sm-4">
+        							<div class="form-group">
+        								<label for="security_code">{l s='CVC' mod='omise'}</label>
+        								<input type="text" class="form-control" id="security_code" placeholder="{l s='CVC' mod='omise'}" />
+        							</div>
+        						</div>
+        					</div>
+        					<button type="submit" class="button btn btn-default">{l s='Checkout' mod='omise'}</button>
+        				</form>
+        			</div>
+        		</div>
+    		</div>
+		</p>
+	</div>
+</div>

--- a/omise/views/templates/hook/payment.tpl
+++ b/omise/views/templates/hook/payment.tpl
@@ -75,5 +75,5 @@ const omiseCreateTokenCallBack = function omiseCreateTokenCallBack(statusCode, r
     alert(response.message);
     document.getElementById("omise_checkout").disabled = false;
   }
-}
+};
 </script>

--- a/omise/views/templates/hook/payment.tpl
+++ b/omise/views/templates/hook/payment.tpl
@@ -6,6 +6,7 @@
 					<div class="col-sm-4">
 						<h3>{$omise_title}</h3>
 						<form>
+							<input type="hidden" id="omise_card_token" name="omise_card_token" />
 							<div class="row">
 								<div class="form-group col-sm-12">
 									<label for="omise_card_number" class="required">&nbsp;{l s='Card number' mod='omise'}</label>
@@ -40,7 +41,7 @@
 									</div>
 								</div>
 							</div>
-							<button class="button btn btn-default">{l s='Checkout' mod='omise'}</button>
+							<button id="omise_checkout" class="button btn btn-default" onclick="omiseCheckout(); return false;">{l s='Checkout' mod='omise'}</button>
 						</form>
 					</div>
 				</div>
@@ -48,3 +49,29 @@
 		</p>
 	</div>
 </div>
+
+<script type="text/javascript" src="https://cdn.omise.co/omise.js.gz"></script>
+
+<script type="text/javascript">
+function omiseCheckout() {
+	document.getElementById("omise_checkout").disabled = true;
+
+	const card = {
+		name: document.getElementById("omise_card_holder_name").value,
+		number: document.getElementById("omise_card_number").value,
+		expiration_month: document.getElementById("omise_card_expiration_month").value,
+		expiration_year: document.getElementById("omise_card_expiration_year").value,
+		security_code: document.getElementById("omise_card_security_code").value
+	};
+
+	Omise.setPublicKey("{$omise_public_key}");
+	Omise.createToken("card", card, function (statusCode, response) {
+		if (statusCode == 200) {
+			document.getElementById("omise_card_token").value = response.id;
+		} else {
+			alert(response.message);
+			document.getElementById("omise_checkout").disabled = false;
+		}
+	});
+}
+</script>

--- a/omise/views/templates/hook/payment.tpl
+++ b/omise/views/templates/hook/payment.tpl
@@ -33,7 +33,7 @@
         						</div>
         					</div>
         					<div class="row">
-        						<div class="col-sm-4">
+        						<div class="col-sm-6">
         							<div class="form-group">
         								<label for="security_code">{l s='Security code' mod='omise'}</label>
         								<input type="password" class="form-control" id="security_code" placeholder="{l s='Security code' mod='omise'}" />

--- a/tests/autoload.php
+++ b/tests/autoload.php
@@ -1,0 +1,18 @@
+<?php
+function autoload($class)
+{
+    static $classes = null;
+
+    if ($classes === null) {
+        $classes = array(
+            'Setting' => 'setting.php',
+            'Omise' => 'omise.php'
+        );
+    }
+
+    if (isset($classes[$class])) {
+        require __DIR__ . '/../omise/' . $classes[$class];
+    }
+}
+
+spl_autoload_register('autoload');

--- a/tests/unit/OmiseTest.php
+++ b/tests/unit/OmiseTest.php
@@ -27,6 +27,7 @@ class OmiseTest extends PHPUnit_Framework_TestCase
             ->setMethods(
                 array(
                     'generateForm',
+                    'getPublicKey',
                     'getTitle',
                     'isModuleEnabled',
                     'isSubmit',
@@ -105,11 +106,15 @@ class OmiseTest extends PHPUnit_Framework_TestCase
     {
         $this->omise->active = true;
         $this->setting->method('isModuleEnabled')->willReturn(true);
+        $this->setting->method('getPublicKey')->willReturn('public_key');
         $this->setting->method('getTitle')->willReturn('title_at_header_of_checkout_form');
 
-        $this->smarty->expects($this->once())
+        $this->smarty->expects($this->exactly(2))
             ->method('assign')
-            ->with('omise_title', 'title_at_header_of_checkout_form');
+            ->withConsecutive(
+                 array('omise_public_key', 'public_key'),
+                 array('omise_title', 'title_at_header_of_checkout_form')
+             );
 
         $this->omise->hookPayment('');
     }

--- a/tests/unit/OmiseTest.php
+++ b/tests/unit/OmiseTest.php
@@ -7,6 +7,7 @@ class OmiseTest extends PHPUnit_Framework_TestCase
 {
     private $omise;
     private $setting;
+    private $smarty;
 
     public function setup()
     {
@@ -26,6 +27,7 @@ class OmiseTest extends PHPUnit_Framework_TestCase
             ->setMethods(
                 array(
                     'generateForm',
+                    'getTitle',
                     'isModuleEnabled',
                     'isSubmit',
                     'save'
@@ -33,8 +35,14 @@ class OmiseTest extends PHPUnit_Framework_TestCase
             )
             ->getMock();
 
+        $this->smarty = $this->getMockBuilder(stdClass::class)
+            ->setMockClassName('Smarty')
+            ->setMethods(array('assign'))
+            ->getMock();
+
         $this->omise = new Omise();
         $this->omise->setSetting($this->setting);
+        $this->omise->setSmarty($this->smarty);
     }
 
     public function testName_omise()
@@ -91,6 +99,19 @@ class OmiseTest extends PHPUnit_Framework_TestCase
         $this->omise->method('display')->willReturn('payment_form');
 
         $this->assertEquals('payment_form', $this->omise->hookPayment(''));
+    }
+
+    public function testHookPayment_moduleIsActivatedAndEnabled_displayTitle()
+    {
+        $this->omise->active = true;
+        $this->setting->method('isModuleEnabled')->willReturn(true);
+        $this->setting->method('getTitle')->willReturn('title_at_header_of_checkout_form');
+
+        $this->smarty->expects($this->once())
+            ->method('assign')
+            ->with('omise_title', 'title_at_header_of_checkout_form');
+
+        $this->omise->hookPayment('');
     }
 
     public function testHookPayment_moduleIsActivatedButModuleIsDisabled_paymentFormMustNotBeDisplayed()

--- a/tests/unit/OmiseTest.php
+++ b/tests/unit/OmiseTest.php
@@ -1,0 +1,119 @@
+<?php
+if (! defined('_PS_VERSION_')) {
+    define('_PS_VERSION_', 'TEST_VERSION');
+}
+
+class OmiseTest extends PHPUnit_Framework_TestCase
+{
+    private $omise;
+    private $setting;
+
+    public function setup()
+    {
+        $this->getMockBuilder(stdClass::class)
+            ->setMockClassName('PaymentModule')
+            ->setMethods(
+                array(
+                    '__construct',
+                    'display',
+                    'displayConfirmation',
+                    'l'
+                )
+            )
+            ->getMock();
+
+        $this->setting = $this->getMockBuilder(Setting::class)
+            ->setMethods(
+                array(
+                    'generateForm',
+                    'isModuleEnabled',
+                    'isSubmit',
+                    'save'
+                )
+            )
+            ->getMock();
+
+        $this->omise = new Omise();
+        $this->omise->setSetting($this->setting);
+    }
+
+    public function testName_omise()
+    {
+        $this->assertEquals('omise', $this->omise->name);
+    }
+
+    public function testDisplayName_Omise()
+    {
+        $this->assertEquals('Omise', $this->omise->displayName);
+    }
+
+    public function testNeedInstance_noNeedToLoadModuleAtTheBackendModulePage()
+    {
+        $this->assertEquals(0, $this->omise->need_instance);
+    }
+
+    public function testBootstrap_bootstrapTemplateIsRequired()
+    {
+        $this->assertEquals(true, $this->omise->bootstrap);
+    }
+
+    public function testConstructor_whenNewTheInstance_theDefaultAttributeSettingMustBeAvailable()
+    {
+        $omise = new Omise();
+
+        $setting = $omise->getSetting();
+
+        $this->assertNotEmpty($setting);
+    }
+
+    public function testGetContent_merchantOpenTheSettingPage_settingMustNotBeSaved()
+    {
+        $this->setting->method('isSubmit')->willReturn(false);
+
+        $this->setting->expects($this->never())->method('save');
+
+        $this->omise->getContent();
+    }
+
+    public function testGetContent_merchantSaveSetting_settingMustBeSaved()
+    {
+        $this->setting->method('isSubmit')->willReturn(true);
+
+        $this->setting->expects($this->once())->method('save');
+
+        $this->omise->getContent();
+    }
+
+    public function testHookPayment_moduleIsActivatedAndEnabled_displayThePaymentForm()
+    {
+        $this->omise->active = true;
+        $this->setting->method('isModuleEnabled')->willReturn(true);
+        $this->omise->method('display')->willReturn('payment_form');
+
+        $this->assertEquals('payment_form', $this->omise->hookPayment(''));
+    }
+
+    public function testHookPayment_moduleIsActivatedButModuleIsDisabled_paymentFormMustNotBeDisplayed()
+    {
+        $this->omise->active = true;
+        $this->setting->method('isModuleEnabled')->willReturn(false);
+
+        $this->assertNull($this->omise->hookPayment(''));
+    }
+
+    public function testHookPayment_moduleIsInactivatedButModuleIsEnabled_paymentFormMustNotBeDisplayed()
+    {
+        $this->omise->active = false;
+        $this->setting->method('isModuleEnabled')->willReturn(true);
+
+        $this->assertNull($this->omise->hookPayment(''));
+    }
+
+    public function testHookPayment_moduleIsInactivatedAndDisabled_paymentFormMustNotBeDisplayed()
+    {
+        $this->omise->active = false;
+        $this->setting->method('isModuleEnabled')->willReturn(false);
+
+        $this->assertNull($this->omise->hookPayment(''));
+    }
+}

--- a/tests/unit/SettingTest.php
+++ b/tests/unit/SettingTest.php
@@ -1,0 +1,82 @@
+<?php
+if (!defined('_PS_VERSION_')) {
+    define('_PS_VERSION_', 'TEST_VERSION');
+}
+
+class SettingTest extends PHPUnit_Framework_TestCase
+{
+    private $form_input;
+    private $setting;
+
+    public function setup()
+    {
+        $this->getMockBuilder(stdClass::class)
+            ->setMockClassName('PaymentModule')
+            ->setMethods(array('l'))
+            ->getMock();
+
+        $this->getMockBuilder(stdClass::class)
+            ->setMockClassName('HelperForm')
+            ->setMethods(array('generateForm'))
+            ->getMock();
+
+        $this->setting = new Setting();
+
+        $fields = $this->setting->getFields();
+        $this->form_input = $fields[0]['form']['input'];
+    }
+
+    public function testSubmitAction_omiseSaveSetting()
+    {
+        $this->assertEquals('omise_save_setting', $this->setting->getSubmitAction());
+    }
+
+    public function testGetFields_formMustHasInputForModuleStatus()
+    {
+        $input_module_status = $this->form_input['module_status'];
+
+        $this->assertEquals('module_status', $input_module_status['name']);
+    }
+
+    public function testGetFields_formMustHasInputForSandboxStatus()
+    {
+        $input_sanbox_status = $this->form_input['sandbox_status'];
+
+        $this->assertEquals('sandbox_status', $input_sanbox_status['name']);
+    }
+
+    public function testGetFields_formMustHasInputForTestPublicKey()
+    {
+        $input_test_public_key = $this->form_input['test_public_key'];
+
+        $this->assertEquals('test_public_key', $input_test_public_key['name']);
+    }
+
+    public function testGetFields_formMustHasInputForTestSecretKey()
+    {
+        $input_test_secret_key = $this->form_input['test_secret_key'];
+
+        $this->assertEquals('test_secret_key', $input_test_secret_key['name']);
+    }
+
+    public function testGetFields_formMustHasInputForLivePublicKey()
+    {
+        $input_live_public_key = $this->form_input['live_public_key'];
+
+        $this->assertEquals('live_public_key', $input_live_public_key['name']);
+    }
+
+    public function testGetFields_formMustHasInputForLiveSecretKey()
+    {
+        $input_live_secret_key = $this->form_input['live_secret_key'];
+
+        $this->assertEquals('live_secret_key', $input_live_secret_key['name']);
+    }
+
+    public function testGetFields_formMustHasInputForTitle()
+    {
+        $input_title = $this->form_input['title'];
+
+        $this->assertEquals('title', $input_title['name']);
+    }
+}


### PR DESCRIPTION
**1. Objective reason**

Create an Omise card token from the valid card information that payer filled in the checkout form. The token will be used to process the charge in the next step.

Related ticket: T1122
Required pull request: [#7](https://github.com/omise/omise-prestashop/pull/7)

**2. Description of change**
- Call the external client side script, Omise.js
- Manipulate the checkout form to create the Omise card token

The screenshot below shows the Omise card token was defined to be the value for HTML hidden after the payer filled the valid card information.

<img width="835" alt="screen shot 2016-09-16 at 3 55 36 am" src="https://cloud.githubusercontent.com/assets/4145121/18567568/f10d281c-7bc2-11e6-9ef0-428225e991d3.png">

**3. Users affected by the change**

All

**4. Impact of the change**

`-`

**5. Priority of change**

Normal

**6. Alternate solution**

`-`
