### PR TITLE
Develop the setting page by using the template file instead of using the array configuration

### DIFF
--- a/omise/omise.php
+++ b/omise/omise.php
@@ -28,6 +28,13 @@ class Omise extends PaymentModule
      */
     const MODULE_VERSION = '1.6.0.0';
 
+    /**
+     * The instance of class, Setting.
+     *
+     * The Setting class is used to manipulate the configuration of module.
+     *
+     * @var \Setting
+     */
     protected $setting;
 
     public function __construct()

--- a/omise/omise.php
+++ b/omise/omise.php
@@ -84,6 +84,9 @@ class Omise extends PaymentModule
         return $this->setting;
     }
 
+    /**
+     * @param \Setting $setting The instance of class, Setting.
+     */
     public function setSetting($setting)
     {
         $this->setting = $setting;

--- a/omise/omise.php
+++ b/omise/omise.php
@@ -76,6 +76,9 @@ class Omise extends PaymentModule
         return $this->display(__FILE__, 'views/templates/admin/setting.tpl');
     }
 
+    /**
+     * @return \Setting
+     */
     public function getSetting()
     {
         return $this->setting;

--- a/omise/omise.php
+++ b/omise/omise.php
@@ -15,7 +15,7 @@ class Omise extends PaymentModule
     const MODULE_DISPLAY_NAME = 'Omise';
 
     /**
-     * The name that used to referece in the program.
+     * The name that used to reference in the program.
      *
      * @var string
      */

--- a/omise/omise.php
+++ b/omise/omise.php
@@ -62,14 +62,16 @@ class Omise extends PaymentModule
             $this->smarty->assign('confirmation', $this->displayConfirmation($this->l('Settings updated')));
         }
 
-        $this->smarty->assign('live_public_key', $this->setting->getLivePublicKey());
-        $this->smarty->assign('live_secret_key', $this->setting->getLiveSecretKey());
-        $this->smarty->assign('module_status', $this->setting->isModuleEnabled());
-        $this->smarty->assign('sandbox_status', $this->setting->isSandboxEnabled());
-        $this->smarty->assign('submit_action', $this->setting->getSubmitAction());
-        $this->smarty->assign('test_public_key', $this->setting->getTestPublicKey());
-        $this->smarty->assign('test_secret_key', $this->setting->getTestSecretKey());
-        $this->smarty->assign('title', $this->setting->getTitle());
+        $this->smarty->assign(array(
+            'live_public_key' => $this->setting->getLivePublicKey(),
+            'live_secret_key' => $this->setting->getLiveSecretKey(),
+            'module_status' => $this->setting->isModuleEnabled(),
+            'sandbox_status' => $this->setting->isSandboxEnabled(),
+            'submit_action' => $this->setting->getSubmitAction(),
+            'test_public_key' => $this->setting->getTestPublicKey(),
+            'test_secret_key' => $this->setting->getTestSecretKey(),
+            'title' => $this->setting->getTitle(),
+        ));
 
         return $this->display(__FILE__, 'views/templates/admin/setting.tpl');
     }

--- a/omise/omise.php
+++ b/omise/omise.php
@@ -1,6 +1,9 @@
 <?php
-if (! defined('_PS_VERSION_'))
+if (! defined('_PS_VERSION_')) {
     exit();
+}
+
+require_once 'setting.php';
 
 class Omise extends PaymentModule
 {
@@ -25,6 +28,8 @@ class Omise extends PaymentModule
      */
     const MODULE_VERSION = '1.6.0.0';
 
+    protected $setting;
+
     public function __construct()
     {
         $this->name                   = self::MODULE_NAME;
@@ -39,101 +44,41 @@ class Omise extends PaymentModule
 
         $this->displayName            = self::MODULE_DISPLAY_NAME;
         $this->confirmUninstall       = $this->l('Are you sure you want to uninstall ' . self::MODULE_DISPLAY_NAME . ' module?');
+
+        $this->setSetting(new Setting());
     }
 
     public function getContent()
     {
-        $fields_form[0]['form'] = array(
-            'legend' => array(
-                'title' => $this->l('Settings')
-            ),
-            'input'  => array(
-                array(
-                    'type'     => 'switch',
-                    'label'    => $this->l('Enable/Disable'),
-                    'name'     => 'module',
-                    'is_bool'  => true,
-                    'desc'     => $this->l('Enable Omise Payment Module.'),
-                    'values'   => array(
-                        array(
-                            'id'    => 'module_enabled',
-                            'value' => 1,
-                            'label' => 'Enabled'
-                        ),
-                        array(
-                            'id'    => 'module_disabled',
-                            'value' => 0,
-                            'label' => 'Disabled'
-                        )
-                    )
-                ),
-                array(
-                    'type'     => 'switch',
-                    'label'    => $this->l('Sandbox'),
-                    'name'     => 'sandbox',
-                    'is_bool'  => true,
-                    'desc'     => $this->l('Enabling sandbox means that all your transactions will be in TEST mode.'),
-                    'values'   => array(
-                        array(
-                            'id'    => 'sandbox_on',
-                            'value' => 1,
-                            'label' => 'Enabled'
-                        ),
-                        array(
-                            'id'    => 'sandbox_off',
-                            'value' => 0,
-                            'label' => 'Disabled'
-                        )
-                    )
-                ),
-                array(
-                    'type'     => 'text',
-                    'label'    => $this->l('Public key for test'),
-                    'name'     => 'publicKeyForTest',
-                    'required' => false,
-                    'desc'     => 'The "Test" mode public key can be found in Omise Dashboard.'
-                ),
-                array(
-                    'type'     => 'text',
-                    'label'    => $this->l('Secret key for test'),
-                    'name'     => 'secretKeyForTest',
-                    'required' => false,
-                    'desc'     => 'The "Test" mode secret key can be found in Omise Dashboard.'
-                ),
-                array(
-                    'type'     => 'text',
-                    'label'    => $this->l('Public key for live'),
-                    'name'     => 'publicKeyForLive',
-                    'required' => false,
-                    'desc'     => 'The "Live" mode public key can be found in Omise Dashboard.'
-                ),
-                array(
-                    'type'     => 'text',
-                    'label'    => $this->l('Secret key for live'),
-                    'name'     => 'secretKeyForLive',
-                    'required' => false,
-                    'desc'     => 'The "Live" mode secret key can be found in Omise Dashboard.'
-                ),
-                array(
-                    'label'    => '<b>Advance Settings</b>'
-                ),
-                array(
-                    'type'     => 'text',
-                    'label'    => $this->l('Title'),
-                    'name'     => 'title',
-                    'required' => false,
-                    'desc'     => 'This controls the title which the user sees during checkout.'
-                )
-            ),
-            'submit' => array(
-                'title' => $this->l('Save'),
-                'class' => 'btn btn-default pull-right'
-            )
-        );
+        if ($this->setting->isSubmit()) {
+            $this->setting->save();
+            $this->smarty->assign('confirmation', $this->displayConfirmation($this->l('Settings updated')));
+        }
 
-        $helper = new HelperForm();
-        $helper->submit_action = 'submit' . $this->name;
+        $this->smarty->assign('live_public_key', $this->setting->getLivePublicKey());
+        $this->smarty->assign('live_secret_key', $this->setting->getLiveSecretKey());
+        $this->smarty->assign('module_status', $this->setting->isModuleEnabled());
+        $this->smarty->assign('sandbox_status', $this->setting->isSandboxEnabled());
+        $this->smarty->assign('submit_action', $this->setting->getSubmitAction());
+        $this->smarty->assign('test_public_key', $this->setting->getTestPublicKey());
+        $this->smarty->assign('test_secret_key', $this->setting->getTestSecretKey());
+        $this->smarty->assign('title', $this->setting->getTitle());
 
-        return $helper->generateForm($fields_form);
+        return $this->display(__FILE__, 'views/templates/admin/setting.tpl');
+    }
+
+    public function getSetting()
+    {
+        return $this->setting;
+    }
+
+    public function setSetting($setting)
+    {
+        $this->setting = $setting;
+    }
+
+    public function setSmarty($smarty)
+    {
+        $this->smarty = $smarty;
     }
 }

--- a/omise/omise.php
+++ b/omise/omise.php
@@ -92,6 +92,9 @@ class Omise extends PaymentModule
         $this->setting = $setting;
     }
 
+    /**
+     * @param \Smarty_Data $smarty The instance of class, Smarty_Data.
+     */
     public function setSmarty($smarty)
     {
         $this->smarty = $smarty;

--- a/omise/setting.php
+++ b/omise/setting.php
@@ -7,11 +7,17 @@ class Setting
 {
     protected $submit_action = 'omise_save_setting';
 
+    /**
+     * @return string
+     */
     public function getLivePublicKey()
     {
         return Configuration::get('live_public_key');
     }
 
+    /**
+     * @return string
+     */
     public function getLiveSecretKey()
     {
         return Configuration::get('live_secret_key');
@@ -26,26 +32,41 @@ class Setting
         return Configuration::get('live_public_key');
     }
 
+    /**
+     * @return string
+     */
     public function getSubmitAction()
     {
         return $this->submit_action;
     }
 
+    /**
+     * @return string
+     */
     public function getTestPublicKey()
     {
         return Configuration::get('test_public_key');
     }
 
+    /**
+     * @return string
+     */
     public function getTestSecretKey()
     {
         return Configuration::get('test_secret_key');
     }
 
+    /**
+     * @return string
+     */
     public function getTitle()
     {
         return Configuration::get('title');
     }
 
+    /**
+     * @return bool
+     */
     public function isModuleEnabled()
     {
         if (Configuration::get('module_status')) {
@@ -55,6 +76,9 @@ class Setting
         return false;
     }
 
+    /**
+     * @return bool
+     */
     public function isSandboxEnabled()
     {
         if (Configuration::get('sandbox_status')) {
@@ -64,6 +88,9 @@ class Setting
         return false;
     }
 
+    /**
+     * @return bool
+     */
     public function isSubmit()
     {
         if (Tools::isSubmit($this->getSubmitAction())) {

--- a/omise/setting.php
+++ b/omise/setting.php
@@ -3,7 +3,7 @@ if (! defined('_PS_VERSION_')) {
     exit();
 }
 
-class Setting extends PaymentModule
+class Setting
 {
     protected $submit_action = 'omise_save_setting';
 

--- a/omise/setting.php
+++ b/omise/setting.php
@@ -1,0 +1,86 @@
+<?php
+if (! defined('_PS_VERSION_')) {
+    exit();
+}
+
+class Setting extends PaymentModule
+{
+    protected $submit_action = 'omise_save_setting';
+
+    public function getLivePublicKey()
+    {
+        return Configuration::get('live_public_key');
+    }
+
+    public function getLiveSecretKey()
+    {
+        return Configuration::get('live_secret_key');
+    }
+
+    public function getPublicKey()
+    {
+        if ($this->isSandboxEnabled()) {
+            return Configuration::get('test_public_key');
+        }
+
+        return Configuration::get('live_public_key');
+    }
+
+    public function getSubmitAction()
+    {
+        return $this->submit_action;
+    }
+
+    public function getTestPublicKey()
+    {
+        return Configuration::get('test_public_key');
+    }
+
+    public function getTestSecretKey()
+    {
+        return Configuration::get('test_secret_key');
+    }
+
+    public function getTitle()
+    {
+        return Configuration::get('title');
+    }
+
+    public function isModuleEnabled()
+    {
+        if (Configuration::get('module_status')) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public function isSandboxEnabled()
+    {
+        if (Configuration::get('sandbox_status')) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public function isSubmit()
+    {
+        if (Tools::isSubmit($this->getSubmitAction())) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public function save()
+    {
+        Configuration::updateValue('module_status', strval(Tools::getValue('module_status')));
+        Configuration::updateValue('sandbox_status', strval(Tools::getValue('sandbox_status')));
+        Configuration::updateValue('test_public_key', strval(Tools::getValue('test_public_key')));
+        Configuration::updateValue('test_secret_key', strval(Tools::getValue('test_secret_key')));
+        Configuration::updateValue('live_public_key', strval(Tools::getValue('live_public_key')));
+        Configuration::updateValue('live_secret_key', strval(Tools::getValue('live_secret_key')));
+        Configuration::updateValue('title', strval(Tools::getValue('title')));
+    }
+}

--- a/omise/views/templates/admin/setting.tpl
+++ b/omise/views/templates/admin/setting.tpl
@@ -1,0 +1,78 @@
+{$confirmation}
+
+<form class="defaultForm form-horizontal" method="post">
+  <div class="panel">
+    <div class="panel-heading">{l s='Settings' mod='omise'}</div>
+    <div class="form-wrapper">
+      <div class="form-group">
+        <label class="control-label col-lg-3">{l s='Enable/Disable' mode='omise'}</label>
+        <div class="col-lg-9">
+          <span class="switch prestashop-switch fixed-width-lg">
+            <input id="module_status_enabled" name="module_status" type="radio" value="1" {if $module_status == 1}checked="checked"{/if}>
+            <label for="module_status_enabled">{l s='Yes' mode='omise'}</label>
+            <input id="module_status_disabled" name="module_status" type="radio" value="0" {if $module_status == 0}checked="checked"{/if}>
+            <label for="module_status_disabled">{l s='No' mode='omise'}</label>
+            <a class="slide-button btn"></a>
+          </span>
+          <p class="help-block">{l s='Enable Omise Payment Module.' mode='omise'}</p>
+        </div>
+      </div>
+      <div class="form-group">
+        <label class="control-label col-lg-3">{l s='Sandbox' mode='omise'}</label>
+        <div class="col-lg-9">
+          <span class="switch prestashop-switch fixed-width-lg">
+            <input id="sandbox_status_enabled" name="sandbox_status" type="radio" value="1" {if $sandbox_status == 1}checked="checked"{/if}>
+            <label for="sandbox_status_enabled">{l s='Yes' mode='omise'}</label>
+            <input id="sandbox_status_disabled" name="sandbox_status" type="radio" value="0" {if $sandbox_status == 0}checked="checked"{/if}>
+            <label for="sandbox_status_disabled">{l s='No' mode='omise'}</label>
+            <a class="slide-button btn"></a>
+          </span>
+          <p class="help-block">{l s='Enabling sandbox means that all your transactions will be in TEST mode.' mode='omise'}</p>
+        </div>
+      </div>
+      <div class="form-group">
+        <label class="control-label col-lg-3" for="test_public_key">{l s='Public key for test' mode='omise'}</label>
+        <div class="col-lg-9">
+          <input id="test_public_key" name="test_public_key" type="text" value="{$test_public_key}">
+          <p class="help-block">{l s='The "Test" mode public key can be found in Omise Dashboard.' mode='omise'}</p>
+        </div>
+      </div>
+      <div class="form-group">
+        <label class="control-label col-lg-3" for="test_secret_key">{l s='Secret key for test' mode='omise'}</label>
+        <div class="col-lg-9">
+          <input id="test_secret_key" name="test_secret_key" type="password" value="{$test_secret_key}">
+          <p class="help-block">{l s='The "Test" mode secret key can be found in Omise Dashboard.' mode='omise'}</p>
+        </div>
+      </div>
+      <div class="form-group">
+        <label class="control-label col-lg-3" for="live_public_key">{l s='Public key for live' mode='omise'}</label>
+        <div class="col-lg-9">
+          <input type="text" id="live_public_key" name="live_public_key" value="{$live_public_key}">
+          <p class="help-block">{l s='The "Live" mode public key can be found in Omise Dashboard.' mode='omise'}</p>
+        </div>
+      </div>
+      <div class="form-group">
+        <label class="control-label col-lg-3" for="live_secret_key">{l s='Secret key for live' mode='omise'}</label>
+        <div class="col-lg-9">
+          <input id="live_secret_key" name="live_secret_key" type="password" value="{$live_secret_key}">
+          <p class="help-block">{l s='The "Live" mode secret key can be found in Omise Dashboard.' mode='omise'}</p>
+        </div>
+      </div>
+      <div class="form-group">
+        <label class="control-label col-lg-3"><b>{l s='Advance Settings' mode='omise'}</b></label>
+      </div>
+      <div class="form-group">
+        <label class="control-label col-lg-3" for="title">{l s='Title' mode='omise'}</label>
+        <div class="col-lg-9">
+          <input id="title" name="title" type="text" value="{$title}">
+          <p class="help-block">{l s='This controls the title which the user sees during checkout.' mode='omise'}</p>
+        </div>
+      </div>
+    </div>
+    <div class="panel-footer">
+      <button class="btn btn-default pull-right" name="{$submit_action}" type="submit" value="1">
+        <i class="process-icon-save"></i>{l s='Save' mode='omise'}
+      </button>
+    </div>
+  </div>
+</form>

--- a/tests/autoload.php
+++ b/tests/autoload.php
@@ -1,9 +1,13 @@
 <?php
-function autoload($class) {
+function autoload($class)
+{
     static $classes = null;
 
     if ($classes === null) {
-        $classes = array('Omise' => 'omise.php');
+        $classes = array(
+            'Omise' => 'omise.php',
+            'Setting' => 'setting.php',
+        );
     }
 
     if (isset($classes[$class])) {

--- a/tests/unit/OmiseTest.php
+++ b/tests/unit/OmiseTest.php
@@ -68,7 +68,7 @@ class OmiseTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('omise', $this->omise->name);
     }
 
-    public function testDisplayName_theNameThatUsedToDisplayeToTheMerchantMustBe_Omise()
+    public function testDisplayName_theNameThatUsedToDisplayToTheMerchantMustBe_Omise()
     {
         $this->assertEquals('Omise', $this->omise->displayName);
     }

--- a/tests/unit/OmiseTest.php
+++ b/tests/unit/OmiseTest.php
@@ -78,7 +78,7 @@ class OmiseTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(0, $this->omise->need_instance);
     }
 
-    public function testBootstrap_bootstrapTemplateIsRequired()
+    public function testBootstrap_configureTheModule_bootstrapTemplateIsRequired()
     {
         $this->assertEquals(true, $this->omise->bootstrap);
     }

--- a/tests/unit/OmiseTest.php
+++ b/tests/unit/OmiseTest.php
@@ -73,7 +73,7 @@ class OmiseTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('Omise', $this->omise->displayName);
     }
 
-    public function testNeedInstance_noNeedToLoadModuleAtTheBackendModulePage()
+    public function testNeedInstance_configureTheModule_noNeedToLoadModuleAtTheBackendModulePage()
     {
         $this->assertEquals(0, $this->omise->need_instance);
     }

--- a/tests/unit/OmiseTest.php
+++ b/tests/unit/OmiseTest.php
@@ -94,18 +94,18 @@ class OmiseTest extends PHPUnit_Framework_TestCase
         $this->setting->method('getTestSecretKey')->willReturn('test_secret_key');
         $this->setting->method('getTitle')->willReturn('title');
 
-        $this->smarty->expects($this->exactly(8))
+        $this->smarty->expects($this->once())
             ->method('assign')
-            ->withConsecutive(
-                array('live_public_key', 'live_public_key'),
-                array('live_secret_key', 'live_secret_key'),
-                array('module_status', 'module_status'),
-                array('sandbox_status', 'sandbox_status'),
-                array('submit_action', 'submit_action'),
-                array('test_public_key', 'test_public_key'),
-                array('test_secret_key', 'test_secret_key'),
-                array('title', 'title')
-            );
+            ->with(array(
+                'live_public_key' => 'live_public_key',
+                'live_secret_key' => 'live_secret_key',
+                'module_status' => 'module_status',
+                'sandbox_status' => 'sandbox_status',
+                'submit_action' => 'submit_action',
+                'test_public_key' => 'test_public_key',
+                'test_secret_key' => 'test_secret_key',
+                'title' => 'title',
+            ));
 
         $this->omise->getContent();
     }

--- a/tests/unit/OmiseTest.php
+++ b/tests/unit/OmiseTest.php
@@ -1,37 +1,121 @@
 <?php
-define('_PS_VERSION_', 'TEST_VERSION');
+if (! defined('_PS_VERSION_')) {
+    define('_PS_VERSION_', 'TEST_VERSION');
+}
 
 class OmiseTest extends PHPUnit_Framework_TestCase
 {
     private $omise;
+    private $setting;
+    private $smarty;
 
     public function setup()
     {
-        $paymentModule = $this->getMockBuilder(stdClass::class)
+        $this->getMockBuilder(stdClass::class)
             ->setMockClassName('PaymentModule')
-            ->setMethods(array('__construct', 'l'))
+            ->setMethods(
+                array(
+                    '__construct',
+                    'display',
+                    'displayConfirmation',
+                    'l',
+                )
+            )
+            ->getMock();
+
+        $this->setting = $this->getMockBuilder(Setting::class)
+            ->setMethods(
+                array(
+                    'getLivePublicKey',
+                    'getLiveSecretKey',
+                    'getSubmitAction',
+                    'getTestPublicKey',
+                    'getTestSecretKey',
+                    'getTitle',
+                    'isModuleEnabled',
+                    'isSandboxEnabled',
+                    'isSubmit',
+                    'save',
+                )
+            )
+            ->getMock();
+
+        $this->smarty = $this->getMockBuilder(stdClass::class)
+            ->setMockClassName('Smarty')
+            ->setMethods(
+                array(
+                    'assign',
+                )
+            )
             ->getMock();
 
         $this->omise = new Omise();
+        $this->omise->setSetting($this->setting);
+        $this->omise->setSmarty($this->smarty);
     }
 
-    public function testName_omise()
+    public function testConstructor_whenNewTheInstance_theDefaultValueOfTheAttributeSettingMustBeAvailable()
+    {
+        $omise = new Omise();
+
+        $setting = $omise->getSetting();
+
+        $this->assertNotEmpty($setting);
+    }
+
+    public function testName_theNameThatUsedToReferenceInTheProgramMustBe_omise()
     {
         $this->assertEquals('omise', $this->omise->name);
     }
 
-    public function testDisplayName_Omise()
+    public function testDisplayName_theNameThatUsedToDisplayeToTheMerchantMustBe_Omise()
     {
         $this->assertEquals('Omise', $this->omise->displayName);
     }
 
-    public function testNeedInstance_0()
+    public function testNeedInstance_noNeedToLoadModuleAtTheBackendModulePage()
     {
         $this->assertEquals(0, $this->omise->need_instance);
     }
 
-    public function testBootstrap_true()
+    public function testBootstrap_bootstrapTemplateIsRequired()
     {
         $this->assertEquals(true, $this->omise->bootstrap);
+    }
+
+    public function testGetContent_merchantOpenTheSettingPage_retrieveSettingDataFromTheDatabaseAndDisplayOnThePage()
+    {
+        $this->setting->method('getLivePublicKey')->willReturn('live_public_key');
+        $this->setting->method('getLiveSecretKey')->willReturn('live_secret_key');
+        $this->setting->method('isModuleEnabled')->willReturn('module_status');
+        $this->setting->method('isSandboxEnabled')->willReturn('sandbox_status');
+        $this->setting->method('getSubmitAction')->willReturn('submit_action');
+        $this->setting->method('getTestPublicKey')->willReturn('test_public_key');
+        $this->setting->method('getTestSecretKey')->willReturn('test_secret_key');
+        $this->setting->method('getTitle')->willReturn('title');
+
+        $this->smarty->expects($this->exactly(8))
+            ->method('assign')
+            ->withConsecutive(
+                array('live_public_key', 'live_public_key'),
+                array('live_secret_key', 'live_secret_key'),
+                array('module_status', 'module_status'),
+                array('sandbox_status', 'sandbox_status'),
+                array('submit_action', 'submit_action'),
+                array('test_public_key', 'test_public_key'),
+                array('test_secret_key', 'test_secret_key'),
+                array('title', 'title')
+            );
+
+        $this->omise->getContent();
+    }
+
+    public function testGetContent_merchantSaveSetting_theSettingDataMustBeSaved()
+    {
+        $this->setting->method('isSubmit')->willReturn(true);
+
+        $this->setting->expects($this->once())->method('save');
+
+        $this->omise->getContent();
     }
 }

--- a/tests/unit/OmiseTest.php
+++ b/tests/unit/OmiseTest.php
@@ -60,7 +60,7 @@ class OmiseTest extends PHPUnit_Framework_TestCase
 
         $setting = $omise->getSetting();
 
-        $this->assertNotEmpty($setting);
+        $this->assertInstanceOf(get_class(new Setting()), $setting);
     }
 
     public function testName_theNameThatUsedToReferenceInTheProgramMustBe_omise()

--- a/tests/unit/OmiseTest.php
+++ b/tests/unit/OmiseTest.php
@@ -54,7 +54,7 @@ class OmiseTest extends PHPUnit_Framework_TestCase
         $this->omise->setSmarty($this->smarty);
     }
 
-    public function testConstructor_whenNewTheInstance_theDefaultValueOfTheAttributeSettingMustBeAvailable()
+    public function testConstructor_whenInitiateTheNewInstance_theDefaultValueOfTheAttributeSettingMustBeAvailable()
     {
         $omise = new Omise();
 

--- a/tests/unit/OmiseTest.php
+++ b/tests/unit/OmiseTest.php
@@ -110,7 +110,7 @@ class OmiseTest extends PHPUnit_Framework_TestCase
         $this->omise->getContent();
     }
 
-    public function testGetContent_merchantSaveSetting_theSettingDataMustBeSaved()
+    public function testGetContent_merchantSaveSetting_saveTheSettingData()
     {
         $this->setting->method('isSubmit')->willReturn(true);
 


### PR DESCRIPTION
**1. Objective reason**

Develop the setting page by using the template file instead of using the array configuration.

At the setting page, it has controls, secret key for test and secret key for live. For one of security best practices which is indicated on the Omise web page, [Secure your Account Secret Keys](https://www.omise.co/security-best-practices#secure-your-account-secret-keys), the type of secret key should be the password not the text.

To implement the type of control to be password and the behavior remain the same as the text, the array configuration is not appropriate. Not only the display style was changed, the core function of PrestaShop is not allowed the value to be displayed on the control that is password type when retrieve the data from the database.

So, to implement the control to be password type, using the template file is more appropriate.

An additional benefit in using the template file is fully customized.

Related ticket: T1062

**2. Description of change**
- Remove the implementation of setting page that is array configuration.
- Display the setting page by using the template file.
- Develop the function to save the setting data.
- Develop the function to retrieve the data and display it on the setting page.

The screenshot below shows the setting page that the control of secret key for test and secret key for live are the password type.

![screenshot-localhost 2016-09-22 10-54-23](https://cloud.githubusercontent.com/assets/4145121/18736643/2bc1bb36-80b3-11e6-8470-5eae621eb560.png)

**3. Users affected by the change**

All

**4. Impact of the change**

`-`

**5. Priority of change**

Normal

**6. Alternate solution**

`-`
