### PR TITLE
Display the checkout form at the front-end

### DIFF
--- a/omise/checkout_form.php
+++ b/omise/checkout_form.php
@@ -1,0 +1,28 @@
+<?php
+if (! defined('_PS_VERSION_')) {
+    exit();
+}
+
+class CheckoutForm
+{
+    /**
+     * Return the list of expiration year.
+     *
+     * The first year in the list is current year.
+     * The last year in the list is next 10 years.
+     *
+     * @return string[]
+     */
+    public function getListOfExpirationYear()
+    {
+        $current_year = date('Y');
+        $list_of_expiration_year = array();
+        $maximum_expiration_year = date('Y') + 10;
+
+        do {
+            $list_of_expiration_year[] = $current_year++;
+        } while ($current_year <= $maximum_expiration_year);
+
+        return $list_of_expiration_year;
+    }
+}

--- a/omise/checkout_form.php
+++ b/omise/checkout_form.php
@@ -11,18 +11,10 @@ class CheckoutForm
      * The first year in the list is current year.
      * The last year in the list is next 10 years.
      *
-     * @return string[]
+     * @return int[]
      */
     public function getListOfExpirationYear()
     {
-        $current_year = date('Y');
-        $list_of_expiration_year = array();
-        $maximum_expiration_year = date('Y') + 10;
-
-        do {
-            $list_of_expiration_year[] = $current_year++;
-        } while ($current_year <= $maximum_expiration_year);
-
-        return $list_of_expiration_year;
+        return range(date('Y'), date('Y') + 10);
     }
 }

--- a/omise/omise.php
+++ b/omise/omise.php
@@ -94,11 +94,7 @@ class Omise extends PaymentModule
 
     public function install()
     {
-        if (parent::install() == false || $this->registerHook('payment') == false) {
-            return false;
-        }
-
-        return true;
+        return parent::install() && $this->registerHook('payment');
     }
 
     /**

--- a/omise/omise.php
+++ b/omise/omise.php
@@ -3,6 +3,7 @@ if (! defined('_PS_VERSION_')) {
     exit();
 }
 
+require_once 'checkout_form.php';
 require_once 'setting.php';
 
 class Omise extends PaymentModule
@@ -37,6 +38,8 @@ class Omise extends PaymentModule
      */
     protected $setting;
 
+    protected $checkout_form;
+
     public function __construct()
     {
         $this->name                   = self::MODULE_NAME;
@@ -52,6 +55,7 @@ class Omise extends PaymentModule
         $this->displayName            = self::MODULE_DISPLAY_NAME;
         $this->confirmUninstall       = $this->l('Are you sure you want to uninstall ' . self::MODULE_DISPLAY_NAME . ' module?');
 
+        $this->setCheckoutForm(new CheckoutForm());
         $this->setSetting(new Setting());
     }
 
@@ -76,12 +80,29 @@ class Omise extends PaymentModule
         return $this->display(__FILE__, 'views/templates/admin/setting.tpl');
     }
 
+    public function hookPayment()
+    {
+        if ($this->active == false || $this->setting->isModuleEnabled() == false) {
+            return;
+        }
+
+        $this->smarty->assign('list_of_expiration_year', $this->checkout_form->getListOfExpirationYear());
+        $this->smarty->assign('omise_title', $this->setting->getTitle());
+
+        return $this->display(__FILE__, 'payment.tpl');
+    }
+
     /**
      * @return \Setting
      */
     public function getSetting()
     {
         return $this->setting;
+    }
+
+    public function setCheckoutForm($checkout_form)
+    {
+        $this->checkout_form = $checkout_form;
     }
 
     /**

--- a/omise/omise.php
+++ b/omise/omise.php
@@ -92,6 +92,15 @@ class Omise extends PaymentModule
         return $this->display(__FILE__, 'payment.tpl');
     }
 
+    public function install()
+    {
+        if (parent::install() == false || $this->registerHook('payment') == false) {
+            return false;
+        }
+
+        return true;
+    }
+
     /**
      * @return \Setting
      */

--- a/omise/setting.php
+++ b/omise/setting.php
@@ -23,13 +23,22 @@ class Setting
         return Configuration::get('live_secret_key');
     }
 
+    /**
+     * Return the public key by checking whether
+     * the current setting for sandbox status is enabled or disabled.
+     *
+     * Return the TEST public key, if the sandbox status is enabled (testing mode).
+     * Return the LIVE public key, if the sandbox status is disabled (live mode).
+     *
+     * @return string
+     */
     public function getPublicKey()
     {
         if ($this->isSandboxEnabled()) {
-            return Configuration::get('test_public_key');
+            return $this->getTestPublicKey();
         }
 
-        return Configuration::get('live_public_key');
+        return $this->getLivePublicKey();
     }
 
     /**

--- a/omise/views/templates/hook/payment.tpl
+++ b/omise/views/templates/hook/payment.tpl
@@ -1,0 +1,70 @@
+<div class="row">
+  <div class="col-xs-12">
+    <p class="payment_module">
+      <div class="box">
+        <div class="row">
+          <div class="col-sm-12">
+            <h3>{$omise_title}</h3>
+          </div>
+          <div class="col-sm-8 col-md-5 col-lg-4">
+              <form id="omise_checkout_form">
+                <input id="omise_card_token" name="omise_card_token" type="hidden">
+                <div class="row">
+                  <div class="form-group col-sm-12">
+                    <label for="omise_card_number">{l s='Card number' mod='omise'}</label>
+                    <input class="form-control" id="omise_card_number" type="text" placeholder="{l s='Card number' mod='omise'}">
+                  </div>
+                </div>
+                <div class="row">
+                  <div class="form-group col-sm-12">
+                      <label for="omise_card_holder_name">{l s='Name on card' mod='omise'}</label>
+                      <input class="form-control" id="omise_card_holder_name" type="text" placeholder="{l s='Name on card' mod='omise'}">
+                    </div>
+                </div>
+                <div class="row">
+                  <div class="col-sm-5">
+                    <div class="form-group">
+                      <label for="omise_card_expiration_month">{l s='Expiration month' mod='omise'}</label>
+                      <select class="form-control" id="omise_card_expiration_month">
+                        <option value="01">01</option>
+                        <option value="02">02</option>
+                        <option value="03">03</option>
+                        <option value="04">04</option>
+                        <option value="05">05</option>
+                        <option value="06">06</option>
+                        <option value="07">07</option>
+                        <option value="08">08</option>
+                        <option value="09">09</option>
+                        <option value="10">10</option>
+                        <option value="11">11</option>
+                        <option value="12">12</option>
+                      </select>
+                    </div>
+                  </div>
+                  <div class="col-xs-12 col-sm-5 pull-right">
+                    <div class="form-group">
+                      <label for="omise_card_expiration_year">{l s='Expiration year' mod='omise'}</label>
+                      <select class="form-control" id="omise_card_expiration_year">
+                        {html_options values=$list_of_expiration_year output=$list_of_expiration_year}
+                      </select>
+                    </div>
+                  </div>
+                </div>
+                <div class="row">
+                  <div class="col-sm-5">
+                    <div class="form-group">
+                      <label for="omise_card_security_code">{l s='Security code' mod='omise'}</label>
+                      <input class="form-control" id="omise_card_security_code" type="password" placeholder="{l s='Security code' mod='omise'}">
+                    </div>
+                  </div>
+                </div>
+            </form>
+            <button class="button btn btn-default standard-checkout button-medium" id="omise_checkout_button">
+              <span id="omise_checkout_text">{l s='Submit Payment' mod='omise'}</span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </p>
+  </div>
+</div>

--- a/tests/autoload.php
+++ b/tests/autoload.php
@@ -5,6 +5,7 @@ function autoload($class)
 
     if ($classes === null) {
         $classes = array(
+            'CheckoutForm' => 'checkout_form.php',
             'Omise' => 'omise.php',
             'Setting' => 'setting.php',
         );

--- a/tests/unit/CheckoutFormTest.php
+++ b/tests/unit/CheckoutFormTest.php
@@ -1,0 +1,38 @@
+<?php
+if (! defined('_PS_VERSION_')) {
+    define('_PS_VERSION_', 'TEST_VERSION');
+}
+
+class CheckoutFormTest extends PHPUnit_Framework_TestCase
+{
+    private $list_of_expiration_year;
+
+    public function setup()
+    {
+        $checkout_form = new CheckoutForm();
+        $this->list_of_expiration_year = $checkout_form->getListOfExpirationYear();
+    }
+
+    public function testGetListOfExpirationYear_getListOfExpirationYear_totalNumberOfExpirationYearMustBe11()
+    {
+        $this->assertEquals(11, count($this->list_of_expiration_year));
+    }
+
+    public function testGetListOfExpirationYear_getListOfExpirationYear_theBeginningOfExpirationYearMustBeCurrentYear()
+    {
+        $current_year = date('Y');
+
+        $beginning_of_expiration_year = $this->list_of_expiration_year[0];
+
+        $this->assertEquals($current_year, $beginning_of_expiration_year);
+    }
+
+    public function testGetListOfExpirationYear_getListOfExpirationYear_theEndingOfExpirationYearMustBeNextTenYears()
+    {
+        $next_ten_year = date('Y') + 10;
+
+        $end_of_expiration_year = end($this->list_of_expiration_year);
+
+        $this->assertEquals($next_ten_year, $end_of_expiration_year);
+    }
+}

--- a/tests/unit/OmiseTest.php
+++ b/tests/unit/OmiseTest.php
@@ -135,7 +135,7 @@ class OmiseTest extends PHPUnit_Framework_TestCase
         $this->setting->method('isModuleEnabled')->willReturn(true);
         $this->omise->method('display')->willReturn('payment_template_file');
 
-        $this->assertEquals('payment_template_file', $this->omise->hookPayment(''));
+        $this->assertEquals('payment_template_file', $this->omise->hookPayment());
     }
 
     public function testHookPayment_moduleIsActivatedAndTheSettingOfModuleStatusIsEnabled_displayCheckoutForm()

--- a/tests/unit/OmiseTest.php
+++ b/tests/unit/OmiseTest.php
@@ -148,9 +148,9 @@ class OmiseTest extends PHPUnit_Framework_TestCase
         $this->smarty->expects($this->exactly(2))
             ->method('assign')
             ->withConsecutive(
-                 array('list_of_expiration_year', 'list_of_expiration_year'),
-                 array('omise_title', 'title_at_header_of_checkout_form')
-             );
+                array('list_of_expiration_year', 'list_of_expiration_year'),
+                array('omise_title', 'title_at_header_of_checkout_form')
+            );
 
         $this->omise->hookPayment();
     }


### PR DESCRIPTION
#### 1. Objective

Display the checkout form at the front-end.

**Related information**:
Related issue: -
Related ticket: 1257
Required pull request: #10 

#### 2. Description of change

- Create a checkout form template file.
- Implement a function, `Omise.hookPayment()`, to check module status and display checkout form. If module status is valid, the checkout form will be displayed.
- Develop a new class and function to generate the list of expiration year.

#### 3. Quality assurance

**Environments:**

- **Platform**: PrestaShop 1.6.1.6
- **Omise plugin**: Omise-PrestaShop 1.6.0.0
- **PHP**: 5.6.28
- **Mozilla Firefox**: 50.1.0

**Details:**

- Make sure that the Omise-PrestaShop has been installed and enabled.
- At the front-end, add a product to cart.
- Proceed to checkout.
- At the step, 05. Payment, the checkout form will be displayed.

The screenshot below shows the checkout form at the front-end.

![screenshot-localhost 1616 2016-12-20 17-45-13](https://cloud.githubusercontent.com/assets/4145121/21347657/2ddf39d8-c6dc-11e6-8a1e-5d34c98ae102.png)

#### 4. Impact of the change

`-`

#### 5. Priority of change

Normal

#### 6. Additional notes

`-`