### PR TITLE
Create an Omise card token

### DIFF
--- a/omise/omise.php
+++ b/omise/omise.php
@@ -87,6 +87,7 @@ class Omise extends PaymentModule
         }
 
         $this->smarty->assign('list_of_expiration_year', $this->checkout_form->getListOfExpirationYear());
+        $this->smarty->assign('omise_public_key', $this->setting->getPublicKey());
         $this->smarty->assign('omise_title', $this->setting->getTitle());
 
         return $this->display(__FILE__, 'payment.tpl');

--- a/omise/views/templates/hook/payment.tpl
+++ b/omise/views/templates/hook/payment.tpl
@@ -101,6 +101,16 @@
     }
   };
 
+  const omiseCheckoutForm = {
+    name: document.getElementById('omise_card_holder_name'),
+    number: document.getElementById('omise_card_number'),
+    expiration_month: document.getElementById('omise_card_expiration_month'),
+    expiration_year: document.getElementById('omise_card_expiration_year'),
+    security_code: document.getElementById('omise_card_security_code'),
+    checkout_button: document.getElementById('omise_checkout_button'),
+    checkout_text: document.getElementById('omise_checkout_text'),
+  };
+
   const omiseLockCheckoutForm = function omiseLockCheckoutForm() {
     document.getElementById('omise_card_holder_name').disabled = true;
     document.getElementById('omise_card_number').disabled = true;

--- a/omise/views/templates/hook/payment.tpl
+++ b/omise/views/templates/hook/payment.tpl
@@ -59,7 +59,7 @@
                   </div>
                 </div>
             </form>
-            <button class="button btn btn-default standard-checkout button-medium" id="omise_checkout_button">
+            <button class="button btn btn-default standard-checkout button-medium" id="omise_checkout_button" onclick="omiseCheckout();">
               <span id="omise_checkout_text">{l s='Submit Payment' mod='omise'}</span>
             </button>
           </div>
@@ -68,3 +68,56 @@
     </p>
   </div>
 </div>
+
+<script src="https://cdn.omise.co/omise.js.gz"></script>
+
+<script>
+  const omiseCheckout = function omiseCheckout() {
+    if (typeof Omise === 'undefined') {
+      alert('{l s='Unable to process the payment, loading the external card processing library is failed. Please contact the merchant.' mod='omise'}');
+      return false;
+    }
+
+    omiseLockCheckoutForm();
+
+    const card = {
+      name: document.getElementById('omise_card_holder_name').value,
+      number: document.getElementById('omise_card_number').value,
+      expiration_month: document.getElementById('omise_card_expiration_month').value,
+      expiration_year: document.getElementById('omise_card_expiration_year').value,
+      security_code: document.getElementById('omise_card_security_code').value,
+    };
+
+    Omise.setPublicKey('{$omise_public_key}');
+    Omise.createToken('card', card, omiseCreateTokenCallback);
+  }
+
+  const omiseCreateTokenCallback = function omiseCreateTokenCallback(statusCode, response) {
+    if (statusCode === 200) {
+      document.getElementById('omise_card_token').value = response.id;
+    } else {
+      alert(response.message);
+      omiseUnlockCheckoutForm();
+    }
+  };
+
+  const omiseLockCheckoutForm = function omiseLockCheckoutForm() {
+    document.getElementById('omise_card_holder_name').disabled = true;
+    document.getElementById('omise_card_number').disabled = true;
+    document.getElementById('omise_card_expiration_month').disabled = true;
+    document.getElementById('omise_card_expiration_year').disabled = true;
+    document.getElementById('omise_card_security_code').disabled = true;
+    document.getElementById('omise_checkout_button').disabled = true;
+    document.getElementById("omise_checkout_text").innerHTML = '{l s='Processing' mod='omise'}';
+  };
+
+  const omiseUnlockCheckoutForm = function omiseUnlockCheckoutForm() {
+    document.getElementById('omise_card_holder_name').disabled = false;
+    document.getElementById('omise_card_number').disabled = false;
+    document.getElementById('omise_card_expiration_month').disabled = false;
+    document.getElementById('omise_card_expiration_year').disabled = false;
+    document.getElementById('omise_card_security_code').disabled = false;
+    document.getElementById('omise_checkout_button').disabled = false;
+    document.getElementById("omise_checkout_text").innerHTML = '{l s='Submit Payment' mod='omise'}';
+  };
+</script>

--- a/omise/views/templates/hook/payment.tpl
+++ b/omise/views/templates/hook/payment.tpl
@@ -78,7 +78,7 @@
       return false;
     }
 
-    omiseLockCheckoutForm();
+    omiseLockCheckoutForm(omiseCheckoutForm);
 
     const card = {
       name: document.getElementById('omise_card_holder_name').value,
@@ -111,14 +111,14 @@
     checkout_text: document.getElementById('omise_checkout_text'),
   };
 
-  const omiseLockCheckoutForm = function omiseLockCheckoutForm() {
-    document.getElementById('omise_card_holder_name').disabled = true;
-    document.getElementById('omise_card_number').disabled = true;
-    document.getElementById('omise_card_expiration_month').disabled = true;
-    document.getElementById('omise_card_expiration_year').disabled = true;
-    document.getElementById('omise_card_security_code').disabled = true;
-    document.getElementById('omise_checkout_button').disabled = true;
-    document.getElementById("omise_checkout_text").innerHTML = '{l s='Processing' mod='omise'}';
+  const omiseLockCheckoutForm = function omiseLockCheckoutForm(form) {
+    form.name.disabled = true;
+    form.number.disabled = true;
+    form.expiration_month.disabled = true;
+    form.expiration_year.disabled = true;
+    form.security_code.disabled = true;
+    form.checkout_button.disabled = true;
+    form.checkout_text.innerHTML = '{l s='Processing' mod='omise'}';
   };
 
   const omiseUnlockCheckoutForm = function omiseUnlockCheckoutForm() {

--- a/omise/views/templates/hook/payment.tpl
+++ b/omise/views/templates/hook/payment.tpl
@@ -97,7 +97,7 @@
       document.getElementById('omise_card_token').value = response.id;
     } else {
       alert(response.message);
-      omiseUnlockCheckoutForm();
+      omiseUnlockCheckoutForm(omiseCheckoutForm);
     }
   };
 
@@ -121,13 +121,13 @@
     form.checkout_text.innerHTML = '{l s='Processing' mod='omise'}';
   };
 
-  const omiseUnlockCheckoutForm = function omiseUnlockCheckoutForm() {
-    document.getElementById('omise_card_holder_name').disabled = false;
-    document.getElementById('omise_card_number').disabled = false;
-    document.getElementById('omise_card_expiration_month').disabled = false;
-    document.getElementById('omise_card_expiration_year').disabled = false;
-    document.getElementById('omise_card_security_code').disabled = false;
-    document.getElementById('omise_checkout_button').disabled = false;
-    document.getElementById("omise_checkout_text").innerHTML = '{l s='Submit Payment' mod='omise'}';
+  const omiseUnlockCheckoutForm = function omiseUnlockCheckoutForm(form) {
+    form.name.disabled = false;
+    form.number.disabled = false;
+    form.expiration_month.disabled = false;
+    form.expiration_year.disabled = false;
+    form.security_code.disabled = false;
+    form.checkout_button.disabled = false;
+    form.checkout_text.innerHTML = '{l s='Submit Payment' mod='omise'}';
   };
 </script>

--- a/omise/views/templates/hook/payment.tpl
+++ b/omise/views/templates/hook/payment.tpl
@@ -81,11 +81,11 @@
     omiseLockCheckoutForm(omiseCheckoutForm);
 
     const card = {
-      name: document.getElementById('omise_card_holder_name').value,
-      number: document.getElementById('omise_card_number').value,
-      expiration_month: document.getElementById('omise_card_expiration_month').value,
-      expiration_year: document.getElementById('omise_card_expiration_year').value,
-      security_code: document.getElementById('omise_card_security_code').value,
+      name: omiseCheckoutForm.name.value,
+      number: omiseCheckoutForm.number.value,
+      expiration_month: omiseCheckoutForm.expiration_month.value,
+      expiration_year: omiseCheckoutForm.expiration_year.value,
+      security_code: omiseCheckoutForm.security_code.value,
     };
 
     Omise.setPublicKey('{$omise_public_key}');

--- a/tests/unit/OmiseTest.php
+++ b/tests/unit/OmiseTest.php
@@ -37,6 +37,7 @@ class OmiseTest extends PHPUnit_Framework_TestCase
                 array(
                     'getLivePublicKey',
                     'getLiveSecretKey',
+                    'getPublicKey',
                     'getSubmitAction',
                     'getTestPublicKey',
                     'getTestSecretKey',
@@ -142,13 +143,15 @@ class OmiseTest extends PHPUnit_Framework_TestCase
     {
         $this->omise->active = true;
         $this->setting->method('isModuleEnabled')->willReturn(true);
+        $this->setting->method('getPublicKey')->willReturn('omise_public_key');
         $this->setting->method('getTitle')->willReturn('title_at_header_of_checkout_form');
         $this->checkout_form->method('getListOfExpirationYear')->willReturn('list_of_expiration_year');
 
-        $this->smarty->expects($this->exactly(2))
+        $this->smarty->expects($this->exactly(3))
             ->method('assign')
             ->withConsecutive(
                 array('list_of_expiration_year', 'list_of_expiration_year'),
+                 array('omise_public_key', 'omise_public_key'),
                 array('omise_title', 'title_at_header_of_checkout_form')
             );
 


### PR DESCRIPTION
#### 1. Objective

Create an Omise card token from the valid card information that payer filled in the checkout form. The token will be used to process the charge in the next step.

**Related information**:
Related issue: -
Related ticket: T1122
Required pull request: #11 

#### 2. Description of change

- Call the external client side script, Omise.js
- Pass a variable, Omise public key, from server side to client side
- Manipulate the checkout form to create the Omise card token

**Note:**
The JavaScript code has followed the [PrestaShop coding standard](http://doc.prestashop.com/display/PS16/Coding+Standards) (at the JavaScript code section).

#### 3. Quality assurance

**Environments:**

- **Platform**: PrestaShop 1.6.1.6
- **Omise plugin**: Omise-PrestaShop 1.6.0.0
- **PHP**: 5.6.28
- **Mozilla Firefox**: 50.1.0

**Details:**

- Make sure that the Omise-PrestaShop has been installed and enabled.
- At the front-end, add a product to cart.
- Proceed to checkout.

**Test case 1: Successfully create Omise card token**
- At the step, 05. Payment, fill the valid card information and click button, Submit Payment.
- The Omise card token will be successfully created and defined to the HTML hidden element, `omise_card_token`.
- The Omise card token will be used to submit to process in the next step.

The screenshot below shows the Omise card token was defined to be the value for HTML hidden after the payer filled the valid card information.

<img width="968" alt="order_-_omise-prestashop" src="https://cloud.githubusercontent.com/assets/4145121/21470534/2fc2735e-cac0-11e6-82ac-77ae7823f603.png">

**Test case 2: Display the error message if card information is invalid**
- At the step, 05. Payment, do not fill any card information and then click button, Submit Payment.
- The system will display the popup contained the error message.

The screenshot below shows the popup contained the error message and it is no Omise card token has been created and defined.

<img width="1208" alt="order_-_omise-prestashop_and_create_an_omise_card_token_by_nimid_ _pull_request__12_ _omise_omise-prestashop" src="https://cloud.githubusercontent.com/assets/4145121/21969867/45e89d46-dbd4-11e6-98d8-73022c41a2f2.png">

#### 4. Impact of the change

`-`

#### 5. Priority of change

Normal

#### 6. Additional Notes

`-`