### PR TITLE
Create an Omise charge

### DIFF
--- a/omise/controllers/front/payment.php
+++ b/omise/controllers/front/payment.php
@@ -1,0 +1,85 @@
+<?php
+if (! defined('_PS_VERSION_')) {
+    exit();
+}
+
+require_once _PS_MODULE_DIR_ . '/omise/libraries/omise-php/lib/Omise.php';
+require_once _PS_MODULE_DIR_ . '/omise/setting.php';
+
+class OmisePaymentModuleFrontController extends ModuleFrontController
+{
+    public $context;
+    public $display_column_left = false;
+
+    public function initContent()
+    {
+        parent::initContent();
+
+        $data = array(
+            'amount' => $this->getAmount(),
+            'card' => $this->getCardToken(),
+            'capture' => $this->getCapture(),
+            'currency' => $this->getCurrency(),
+            'description' => $this->getDescription(),
+        );
+
+        $secret_key = $this->getSecretKey();
+
+        try {
+            $charge = OmiseCharge::create($data, '', $secret_key);
+            $payment_success = true;
+        } catch (Exception $e) {
+            $payment_success = false;
+            $this->context->smarty->assign(
+                array(
+                    'error_message' => $e->getMessage(),
+                )
+            );
+        }
+
+        $this->context->smarty->assign(
+            array(
+                'payment_success' => $payment_success,
+            )
+        );
+
+        $this->setTemplate('payment_result.tpl');
+    }
+
+    public function getAmount()
+    {
+        $total = (float) $this->context->cart->getOrderTotal(true, Cart::BOTH);
+
+        return 100 * $total;
+    }
+
+    public function getCardToken()
+    {
+        return Tools::getValue('omise_card_token');
+    }
+
+    public function getCapture()
+    {
+        return 'true';
+    }
+
+    public function getCurrency()
+    {
+        $currency_id = (int) $this->context->cart->id_currency;
+        $currency_instance = Currency::getCurrencyInstance($currency_id);
+
+        return $currency_instance->iso_code;
+    }
+
+    public function getDescription()
+    {
+        return 'PrestaShop';
+    }
+
+    public function getSecretKey()
+    {
+        $setting = new Setting();
+
+        return $setting->getSecretKey();
+    }
+}

--- a/omise/libraries/omise-plugin/Omise.php
+++ b/omise/libraries/omise-plugin/Omise.php
@@ -1,0 +1,2 @@
+<?php
+require_once dirname(__FILE__) . '/helpers/charge.php';

--- a/omise/libraries/omise-plugin/helpers/charge.php
+++ b/omise/libraries/omise-plugin/helpers/charge.php
@@ -1,0 +1,22 @@
+<?php
+if (! class_exists('OmisePluginHelperCharge')) {
+    class OmisePluginHelperCharge
+    {
+        /**
+         *
+         * @param string $currency
+         * @param integer $amount
+         * @return string
+         */
+        public static function amount($currency, $amount)
+        {
+            switch (strtoupper($currency)) {
+                case 'THB':
+                    $amount = $amount * 100;
+                    break;
+            }
+
+            return $amount;
+        }
+    }
+}

--- a/omise/setting.php
+++ b/omise/setting.php
@@ -42,6 +42,24 @@ class Setting
     }
 
     /**
+     * Return the secret key by checking whether
+     * the current setting for sandbox status is enabled or disabled.
+     *
+     * Return the TEST secret key, if the sandbox status is enabled (testing mode).
+     * Return the LIVE secret key, if the sandbox status is disabled (live mode).
+     *
+     * @return string
+     */
+    public function getSecretKey()
+    {
+        if ($this->isSandboxEnabled()) {
+            return $this->getTestSecretKey();
+        }
+
+        return $this->getLiveSecretKey();
+    }
+
+    /**
      * @return string
      */
     public function getSubmitAction()

--- a/omise/views/templates/front/payment_result.tpl
+++ b/omise/views/templates/front/payment_result.tpl
@@ -4,12 +4,12 @@
 
 <h2>{l s='Order result' mod='omise'}</h2>
 
-{if $payment_success == 'true'}
+{if $error_message}
   <p>
-    Payment Success
+    Payment Failed, {$error_message}
   </p>
 {else}
   <p>
-    Payment Failed, {$error_message}
+    Payment Success
   </p>
 {/if}

--- a/omise/views/templates/front/payment_result.tpl
+++ b/omise/views/templates/front/payment_result.tpl
@@ -1,0 +1,15 @@
+{capture name=path}
+    {l s='Order result' mod='omise'}
+{/capture}
+
+<h2>{l s='Order result' mod='omise'}</h2>
+
+{if $payment_success == 'true'}
+  <p>
+    Payment Success
+  </p>
+{else}
+  <p>
+    Payment Failed, {$error_message}
+  </p>
+{/if}

--- a/omise/views/templates/hook/payment.tpl
+++ b/omise/views/templates/hook/payment.tpl
@@ -7,7 +7,7 @@
             <h3>{$omise_title}</h3>
           </div>
           <div class="col-sm-8 col-md-5 col-lg-4">
-              <form id="omise_checkout_form">
+              <form id="omise_checkout_form" method="post" action="{$link->getModuleLink('omise', 'payment', [], true)|escape:'html'}">
                 <input id="omise_card_token" name="omise_card_token" type="hidden">
                 <div class="row">
                   <div class="form-group col-sm-12">
@@ -95,6 +95,7 @@
   const omiseCreateTokenCallback = function omiseCreateTokenCallback(statusCode, response) {
     if (statusCode === 200) {
       document.getElementById('omise_card_token').value = response.id;
+      document.getElementById('omise_checkout_form').submit();
     } else {
       alert(response.message);
       omiseUnlockCheckoutForm(omiseCheckoutForm);


### PR DESCRIPTION
#### 1. Objective

Create an Omise charge by using the Omise card token that submitted from the client side.

**Related information**:
Related issue: -
Related ticket: -
Required pull request: #13 

#### 2. Description of change

- Add a helper class and a function, `OmisePluginHelperCharge.amount()` to format the charge amount for the Thai Baht currency.
- Complete the checkout form function to submit the Omise card token from client side to server side.
- Implement a class to process charge at server side.
- Add a dummy page for display the checkout result.

#### 3. Quality assurance

**Environments:**

- **Platform**: PrestaShop 1.6.1.6
- **Omise plugin**: Omise-PrestaShop 1.6.0.0
- **PHP**: 5.6.28
- **Mozilla Firefox**: 50.1.0

**Details:**

- Make sure that the Omise-PrestaShop has been installed and enabled.
- At the front-end, add a product to cart.
- Proceed to checkout.
- At the step, 05. Payment, fill the valid card information and click button, Submit Payment. The system will process the payment and display the result page.

The screenshot below shows the result page display the successful payment.

![screenshot-localhost 1616 2016-12-26 14-19-39](https://cloud.githubusercontent.com/assets/4145121/21478066/756c590a-cb7a-11e6-8dd3-4bc0f45f8eee.png)

The screenshot below shows charge detail at Omise dashboard. This charge was created from the above checkout.

![screenshot-dashboard omise co 2016-12-26 14-21-32](https://cloud.githubusercontent.com/assets/4145121/21478117/df71c678-cb7a-11e6-9905-ca6ff3d12c89.png)

#### 4. Impact of the change

`-`

#### 5. Priority of change

Normal

#### 6. Additional notes

For the next steps of charge process, such as record the order information to PrestaShop or display the proper result page, it will be developed for next pull request.