### PR TITLE
Implement function to save an order after created Omise charge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .buildpath
 .project
 .settings/
+vendor/
+

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,5 @@
+{
+    "require-dev": {
+        "mockery/mockery": "dev-master"
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,9 @@
 {
     "require-dev": {
         "mockery/mockery": "dev-master"
+    },
+    "autoload": {
+        "classmap": ["omise/"],
+        "exclude-from-classmap": ["/omise/libraries/"]
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,134 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
+    ],
+    "hash": "293c33ec85fc878db8556281efb862ec",
+    "content-hash": "ead74161f1692cddf0294551ac9027fe",
+    "packages": [],
+    "packages-dev": [
+        {
+            "name": "hamcrest/hamcrest-php",
+            "version": "v2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/hamcrest/hamcrest-php.git",
+                "reference": "776503d3a8e85d4f9a1148614f95b7a608b046ad"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/hamcrest/hamcrest-php/zipball/776503d3a8e85d4f9a1148614f95b7a608b046ad",
+                "reference": "776503d3a8e85d4f9a1148614f95b7a608b046ad",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3|^7.0"
+            },
+            "replace": {
+                "cordoval/hamcrest-php": "*",
+                "davedevelopment/hamcrest-php": "*",
+                "kodova/hamcrest-php": "*"
+            },
+            "require-dev": {
+                "phpunit/php-file-iterator": "1.3.3",
+                "phpunit/phpunit": "~4.0",
+                "satooshi/php-coveralls": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "hamcrest"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD"
+            ],
+            "description": "This is the PHP port of Hamcrest Matchers",
+            "keywords": [
+                "test"
+            ],
+            "time": "2016-01-20 08:20:44"
+        },
+        {
+            "name": "mockery/mockery",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/padraic/mockery.git",
+                "reference": "d4f0db56642357c87e967beba75157fcdb9b0cca"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/padraic/mockery/zipball/d4f0db56642357c87e967beba75157fcdb9b0cca",
+                "reference": "d4f0db56642357c87e967beba75157fcdb9b0cca",
+                "shasum": ""
+            },
+            "require": {
+                "hamcrest/hamcrest-php": "~2.0",
+                "lib-pcre": ">=7.0",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Mockery": "library/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Pádraic Brady",
+                    "email": "padraic.brady@gmail.com",
+                    "homepage": "http://blog.astrumfutura.com"
+                },
+                {
+                    "name": "Dave Marshall",
+                    "email": "dave.marshall@atstsolutions.co.uk",
+                    "homepage": "http://davedevelopment.co.uk"
+                }
+            ],
+            "description": "Mockery is a simple yet flexible PHP mock object framework for use in unit testing with PHPUnit, PHPSpec or any other testing framework. Its core goal is to offer a test double framework with a succinct API capable of clearly defining all possible object operations and interactions using a human readable Domain Specific Language (DSL). Designed as a drop in alternative to PHPUnit's phpunit-mock-objects library, Mockery is easy to integrate with PHPUnit and can operate alongside phpunit-mock-objects without the World ending.",
+            "homepage": "http://github.com/padraic/mockery",
+            "keywords": [
+                "BDD",
+                "TDD",
+                "library",
+                "mock",
+                "mock objects",
+                "mockery",
+                "stub",
+                "test",
+                "test double",
+                "testing"
+            ],
+            "time": "2017-01-03 20:33:07"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {
+        "mockery/mockery": 20
+    },
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": []
+}

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "293c33ec85fc878db8556281efb862ec",
+    "hash": "bfd5ea2eba5f8e2ffb71bfa145500cc3",
     "content-hash": "ead74161f1692cddf0294551ac9027fe",
     "packages": [],
     "packages-dev": [
@@ -62,21 +62,21 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/padraic/mockery.git",
-                "reference": "d4f0db56642357c87e967beba75157fcdb9b0cca"
+                "reference": "e20e6dc435a9ef68fcf566dad8b232f170a1e3c1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/padraic/mockery/zipball/d4f0db56642357c87e967beba75157fcdb9b0cca",
-                "reference": "d4f0db56642357c87e967beba75157fcdb9b0cca",
+                "url": "https://api.github.com/repos/padraic/mockery/zipball/e20e6dc435a9ef68fcf566dad8b232f170a1e3c1",
+                "reference": "e20e6dc435a9ef68fcf566dad8b232f170a1e3c1",
                 "shasum": ""
             },
             "require": {
                 "hamcrest/hamcrest-php": "~2.0",
                 "lib-pcre": ">=7.0",
-                "php": ">=5.4.0"
+                "php": ">=5.6.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.0"
+                "phpunit/phpunit": "~5.7"
             },
             "type": "library",
             "extra": {
@@ -119,7 +119,7 @@
                 "test double",
                 "testing"
             ],
-            "time": "2017-01-03 20:33:07"
+            "time": "2017-02-16 08:49:25"
         }
     ],
     "aliases": [],

--- a/omise/classes/charge.php
+++ b/omise/classes/charge.php
@@ -1,0 +1,9 @@
+<?php
+if (! defined('_PS_VERSION_')) {
+    exit();
+}
+
+class Charge
+{
+
+}

--- a/omise/classes/charge.php
+++ b/omise/classes/charge.php
@@ -16,7 +16,7 @@ class Charge extends ModuleFrontController
         $charge_request = array(
             'amount' => $this->getAmount(),
             'card' => $this->getCardToken(),
-            'capture' => $this->getCapture(),
+            'capture' => 'true',
             'currency' => $this->getCurrencyCode(),
             'description' => $this->getChargeDescription(),
         );
@@ -35,11 +35,6 @@ class Charge extends ModuleFrontController
     protected function getCardToken()
     {
         return Tools::getValue('omise_card_token');
-    }
-
-    protected function getCapture()
-    {
-        return 'true';
     }
 
     protected function getChargeDescription()

--- a/omise/classes/charge.php
+++ b/omise/classes/charge.php
@@ -3,7 +3,47 @@ if (! defined('_PS_VERSION_')) {
     exit();
 }
 
+require_once _PS_MODULE_DIR_ . '/omise/libraries/omise-php/lib/Omise.php';
+require_once _PS_MODULE_DIR_ . '/omise/libraries/omise-plugin/Omise.php';
+require_once _PS_MODULE_DIR_ . '/omise/setting.php';
+
 class Charge extends ModuleFrontController
 {
+    public function getAmount()
+    {
+        $currency_code = $this->getCurrencyCode();
+        $order_total = (float) $this->context->cart->getOrderTotal(true, Cart::BOTH);
 
+        return OmisePluginHelperCharge::amount($currency_code, $order_total);
+    }
+
+    public function getCardToken()
+    {
+        return Tools::getValue('omise_card_token');
+    }
+
+    public function getCapture()
+    {
+        return 'true';
+    }
+
+    public function getChargeDescription()
+    {
+        return 'Charge a card using a token from PrestaShop (' . _PS_VERSION_ . ')';
+    }
+
+    public function getCurrencyCode()
+    {
+        $currency_id = (int) $this->context->cart->id_currency;
+        $currency_instance = Currency::getCurrencyInstance($currency_id);
+
+        return $currency_instance->iso_code;
+    }
+
+    public function getSecretKey()
+    {
+        $setting = new Setting();
+
+        return $setting->getSecretKey();
+    }
 }

--- a/omise/classes/charge.php
+++ b/omise/classes/charge.php
@@ -3,9 +3,11 @@ if (! defined('_PS_VERSION_')) {
     exit();
 }
 
-require_once _PS_MODULE_DIR_ . '/omise/libraries/omise-php/lib/Omise.php';
-require_once _PS_MODULE_DIR_ . '/omise/libraries/omise-plugin/Omise.php';
-require_once _PS_MODULE_DIR_ . '/omise/setting.php';
+if (defined('_PS_MODULE_DIR_')) {
+    require_once _PS_MODULE_DIR_ . '/omise/libraries/omise-php/lib/Omise.php';
+    require_once _PS_MODULE_DIR_ . '/omise/libraries/omise-plugin/Omise.php';
+    require_once _PS_MODULE_DIR_ . '/omise/setting.php';
+}
 
 class Charge extends ModuleFrontController
 {

--- a/omise/classes/charge.php
+++ b/omise/classes/charge.php
@@ -9,7 +9,7 @@ require_once _PS_MODULE_DIR_ . '/omise/setting.php';
 
 class Charge extends ModuleFrontController
 {
-    public function getAmount()
+    protected function getAmount()
     {
         $currency_code = $this->getCurrencyCode();
         $order_total = (float) $this->context->cart->getOrderTotal(true, Cart::BOTH);
@@ -17,22 +17,22 @@ class Charge extends ModuleFrontController
         return OmisePluginHelperCharge::amount($currency_code, $order_total);
     }
 
-    public function getCardToken()
+    protected function getCardToken()
     {
         return Tools::getValue('omise_card_token');
     }
 
-    public function getCapture()
+    protected function getCapture()
     {
         return 'true';
     }
 
-    public function getChargeDescription()
+    protected function getChargeDescription()
     {
         return 'Charge a card using a token from PrestaShop (' . _PS_VERSION_ . ')';
     }
 
-    public function getCurrencyCode()
+    protected function getCurrencyCode()
     {
         $currency_id = (int) $this->context->cart->id_currency;
         $currency_instance = Currency::getCurrencyInstance($currency_id);
@@ -40,7 +40,7 @@ class Charge extends ModuleFrontController
         return $currency_instance->iso_code;
     }
 
-    public function getSecretKey()
+    protected function getSecretKey()
     {
         $setting = new Setting();
 

--- a/omise/classes/charge.php
+++ b/omise/classes/charge.php
@@ -9,6 +9,19 @@ require_once _PS_MODULE_DIR_ . '/omise/setting.php';
 
 class Charge extends ModuleFrontController
 {
+    public function create()
+    {
+        $charge_request = array(
+            'amount' => $this->getAmount(),
+            'card' => $this->getCardToken(),
+            'capture' => $this->getCapture(),
+            'currency' => $this->getCurrencyCode(),
+            'description' => $this->getChargeDescription(),
+        );
+
+        return OmiseCharge::create($charge_request, '', $this->getSecretKey());
+    }
+
     protected function getAmount()
     {
         $currency_code = $this->getCurrencyCode();

--- a/omise/classes/charge.php
+++ b/omise/classes/charge.php
@@ -3,7 +3,7 @@ if (! defined('_PS_VERSION_')) {
     exit();
 }
 
-class Charge
+class Charge extends ModuleFrontController
 {
 
 }

--- a/omise/classes/payment_order.php
+++ b/omise/classes/payment_order.php
@@ -46,6 +46,16 @@ class PaymentOrder extends ModuleFrontController
         return $this->module->displayName;
     }
 
+    protected function getModuleId()
+    {
+        return (int) $this->module->id;
+    }
+
+    protected function getModuleCurrentOrder()
+    {
+        return $this->module->currentOrder;
+    }
+
     /**
      * The optional message that will be used to attach to the order.
      *
@@ -78,6 +88,16 @@ class PaymentOrder extends ModuleFrontController
     protected function isNotNeededRoundingCardOrderTotal()
     {
         return false;
+    }
+
+    public function redirectToResultPage()
+    {
+        Tools::redirect('index.php?controller=order-confirmation' .
+            '&id_cart=' . $this->getCartId() .
+            '&id_module=' . $this->getModuleId() .
+            '&id_order=' . $this->getModuleCurrentOrder() .
+            '&key=' . $this->getCustomerSecureKey()
+        );
     }
 
     public function save()

--- a/omise/classes/payment_order.php
+++ b/omise/classes/payment_order.php
@@ -3,6 +3,6 @@ if (! defined('_PS_VERSION_')) {
     exit();
 }
 
-class PaymentOrder
+class PaymentOrder extends ModuleFrontController
 {
 }

--- a/omise/classes/payment_order.php
+++ b/omise/classes/payment_order.php
@@ -5,4 +5,93 @@ if (! defined('_PS_VERSION_')) {
 
 class PaymentOrder extends ModuleFrontController
 {
+    protected function getCartId()
+    {
+        $cart = $this->context->cart;
+        return (int) $cart->id;
+    }
+
+    protected function getCartOrderTotal()
+    {
+        $cart = $this->context->cart;
+        return (float) $cart->getOrderTotal();
+    }
+
+    protected function getCustomerSecureKey()
+    {
+        $cart = $this->context->cart;
+        $customer = new Customer($cart->id_customer);
+
+        return $customer->secure_key;
+    }
+
+    protected function getCurrencyId()
+    {
+        $currency = $this->context->currency;
+        return (int) $currency->id;
+    }
+
+    /**
+     * The array of extra variables that will be used to attach to the order email.
+     *
+     * @return array
+     */
+    protected function getExtraVariables()
+    {
+        return array();
+    }
+
+    protected function getModuleDisplayName()
+    {
+        return $this->module->displayName;
+    }
+
+    /**
+     * The optional message that will be used to attach to the order.
+     *
+     * @return string
+     */
+    protected function getOptionalMessage()
+    {
+        return null;
+    }
+
+    /**
+     * The successful order status.
+     *
+     * @return mixed
+     */
+    protected function getOrderStateAcceptedPayment()
+    {
+        return Configuration::get('PS_OS_PAYMENT');
+    }
+
+    /**
+     * The flag that used to indicate that the PrestaShop need to
+     * round the card order total amount.
+     *
+     * If the flag is false, the PrestaShop will perform rounding.
+     * If the flag is true, the PrestaShop WILL NOT preform rounding.
+     *
+     * @return bool
+     */
+    protected function isNotNeededRoundingCardOrderTotal()
+    {
+        return false;
+    }
+
+    public function save()
+    {
+        $this->module->validateOrder(
+            $this->getCartId(),
+            $this->getOrderStateAcceptedPayment(),
+            $this->getCartOrderTotal(),
+            $this->getModuleDisplayName(),
+            $this->getOptionalMessage(),
+            $this->getExtraVariables(),
+            $this->getCurrencyId(),
+            $this->isNotNeededRoundingCardOrderTotal(),
+            $this->getCustomerSecureKey()
+        );
+    }
 }

--- a/omise/classes/payment_order.php
+++ b/omise/classes/payment_order.php
@@ -1,0 +1,8 @@
+<?php
+if (! defined('_PS_VERSION_')) {
+    exit();
+}
+
+class PaymentOrder
+{
+}

--- a/omise/controllers/front/payment.php
+++ b/omise/controllers/front/payment.php
@@ -14,18 +14,10 @@ class OmisePaymentModuleFrontController extends ModuleFrontController
     {
         parent::initContent();
 
-        $charge_request = array(
-            'amount' => $this->getAmount(),
-            'card' => $this->getCardToken(),
-            'capture' => $this->getCapture(),
-            'currency' => $this->getCurrencyCode(),
-            'description' => $this->getChargeDescription(),
-        );
-
-        $secret_key = $this->getSecretKey();
+        $omiseCharge = new Charge();
 
         try {
-            $charge = OmiseCharge::create($charge_request, '', $secret_key);
+            $omiseCharge->create();
         } catch (Exception $e) {
             $this->context->smarty->assign('error_message', $e->getMessage());
         }

--- a/omise/controllers/front/payment.php
+++ b/omise/controllers/front/payment.php
@@ -11,21 +11,33 @@ if (defined('_PS_MODULE_DIR_')) {
 class OmisePaymentModuleFrontController extends ModuleFrontController
 {
     public $display_column_left = false;
+    protected $payment_order;
+
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->setPaymentOrder(new PaymentOrder());
+    }
 
     public function initContent()
     {
         parent::initContent();
 
         $omiseCharge = new Charge();
-        $payment_order = new PaymentOrder();
 
         try {
             $omiseCharge->create();
-            $payment_order->save();
+            $this->payment_order->save();
         } catch (Exception $e) {
             $this->context->smarty->assign('error_message', $e->getMessage());
         }
 
         $this->payment_order->redirectToResultPage();
+    }
+
+    public function setPaymentOrder($payment_order)
+    {
+        $this->payment_order = $payment_order;
     }
 }

--- a/omise/controllers/front/payment.php
+++ b/omise/controllers/front/payment.php
@@ -1,0 +1,85 @@
+<?php
+if (! defined('_PS_VERSION_')) {
+    exit();
+}
+
+require_once _PS_MODULE_DIR_ . '/omise/libraries/omise-php/lib/Omise.php';
+require_once _PS_MODULE_DIR_ . '/omise/setting.php';
+
+class OmisePaymentModuleFrontController extends ModuleFrontController
+{
+    public $context;
+    public $display_column_left = false;
+
+    public function initContent()
+    {
+        parent::initContent();
+
+        $data = array(
+            'amount' => $this->getAmount(),
+            'card' => $this->getCardToken(),
+            'capture' => $this->getCapture(),
+            'currency' => $this->getCurrency(),
+            'description' => $this->getDescription(),
+        );
+
+        $secret_key = $this->getSecretKey();
+
+        try {
+            $charge = OmiseCharge::create($data, '', $secret_key);
+            $payment_success = true;
+        } catch (Exception $e) {
+            $payment_success = false;
+            $this->context->smarty->assign(
+                array(
+                    'error_message' => $e->getMessage(),
+                )
+            );
+        }
+
+        $this->context->smarty->assign(
+            array(
+                'payment_success' => $payment_success,
+            )
+        );
+
+        $this->setTemplate('payment_result.tpl');
+    }
+
+    public function getAmount()
+    {
+        $total = (float) $this->context->cart->getOrderTotal(true, Cart::BOTH);
+
+        return 100 * $total;
+    }
+
+    public function getCardToken()
+    {
+        return Tools::getValue('omise_card_token');
+    }
+
+    public function getCapture()
+    {
+        return 'true';
+    }
+
+    public function getCurrency()
+    {
+        $currency_id = (int) $this->context->cart->id_currency;
+        $currency_instance = Currency::getCurrencyInstance($currency_id);
+
+        return $currency_instance->iso_code;
+    }
+
+    public function getDescription()
+    {
+        return 'PrestaShop';
+    }
+
+    public function getSecretKey()
+    {
+        $setting = new Setting();
+
+        return $setting->getSecretKey();
+    }
+}

--- a/omise/controllers/front/payment.php
+++ b/omise/controllers/front/payment.php
@@ -3,10 +3,6 @@ if (! defined('_PS_VERSION_')) {
     exit();
 }
 
-require_once _PS_MODULE_DIR_ . '/omise/libraries/omise-php/lib/Omise.php';
-require_once _PS_MODULE_DIR_ . '/omise/libraries/omise-plugin/Omise.php';
-require_once _PS_MODULE_DIR_ . '/omise/setting.php';
-
 class OmisePaymentModuleFrontController extends ModuleFrontController
 {
     public $context;

--- a/omise/controllers/front/payment.php
+++ b/omise/controllers/front/payment.php
@@ -3,6 +3,8 @@ if (! defined('_PS_VERSION_')) {
     exit();
 }
 
+require_once _PS_MODULE_DIR_ . '/omise/classes/charge.php';
+
 class OmisePaymentModuleFrontController extends ModuleFrontController
 {
     public $context;

--- a/omise/controllers/front/payment.php
+++ b/omise/controllers/front/payment.php
@@ -26,6 +26,6 @@ class OmisePaymentModuleFrontController extends ModuleFrontController
             $this->context->smarty->assign('error_message', $e->getMessage());
         }
 
-        $this->setTemplate('payment_result.tpl');
+        $this->payment_order->redirectToResultPage();
     }
 }

--- a/omise/controllers/front/payment.php
+++ b/omise/controllers/front/payment.php
@@ -5,6 +5,7 @@ if (! defined('_PS_VERSION_')) {
 
 if (defined('_PS_MODULE_DIR_')) {
     require_once _PS_MODULE_DIR_ . '/omise/classes/charge.php';
+    require_once _PS_MODULE_DIR_ . '/omise/classes/payment_order.php';
 }
 
 class OmisePaymentModuleFrontController extends ModuleFrontController

--- a/omise/controllers/front/payment.php
+++ b/omise/controllers/front/payment.php
@@ -9,7 +9,6 @@ if (defined('_PS_MODULE_DIR_')) {
 
 class OmisePaymentModuleFrontController extends ModuleFrontController
 {
-    public $context;
     public $display_column_left = false;
 
     public function initContent()

--- a/omise/controllers/front/payment.php
+++ b/omise/controllers/front/payment.php
@@ -34,42 +34,4 @@ class OmisePaymentModuleFrontController extends ModuleFrontController
 
         $this->setTemplate('payment_result.tpl');
     }
-
-    public function getAmount()
-    {
-        $currency_code = $this->getCurrencyCode();
-        $order_total = (float) $this->context->cart->getOrderTotal(true, Cart::BOTH);
-
-        return OmisePluginHelperCharge::amount($currency_code, $order_total);
-    }
-
-    public function getCardToken()
-    {
-        return Tools::getValue('omise_card_token');
-    }
-
-    public function getCapture()
-    {
-        return 'true';
-    }
-
-    public function getChargeDescription()
-    {
-        return 'Charge a card using a token from PrestaShop (' . _PS_VERSION_ . ')';
-    }
-
-    public function getCurrencyCode()
-    {
-        $currency_id = (int) $this->context->cart->id_currency;
-        $currency_instance = Currency::getCurrencyInstance($currency_id);
-
-        return $currency_instance->iso_code;
-    }
-
-    public function getSecretKey()
-    {
-        $setting = new Setting();
-
-        return $setting->getSecretKey();
-    }
 }

--- a/omise/controllers/front/payment.php
+++ b/omise/controllers/front/payment.php
@@ -17,9 +17,11 @@ class OmisePaymentModuleFrontController extends ModuleFrontController
         parent::initContent();
 
         $omiseCharge = new Charge();
+        $payment_order = new PaymentOrder();
 
         try {
             $omiseCharge->create();
+            $payment_order->save();
         } catch (Exception $e) {
             $this->context->smarty->assign('error_message', $e->getMessage());
         }

--- a/omise/controllers/front/payment.php
+++ b/omise/controllers/front/payment.php
@@ -3,7 +3,9 @@ if (! defined('_PS_VERSION_')) {
     exit();
 }
 
-require_once _PS_MODULE_DIR_ . '/omise/classes/charge.php';
+if (defined('_PS_MODULE_DIR_')) {
+    require_once _PS_MODULE_DIR_ . '/omise/classes/charge.php';
+}
 
 class OmisePaymentModuleFrontController extends ModuleFrontController
 {

--- a/omise/libraries/omise-plugin/Omise.php
+++ b/omise/libraries/omise-plugin/Omise.php
@@ -1,0 +1,2 @@
+<?php
+require_once dirname(__FILE__) . '/helpers/charge.php';

--- a/omise/libraries/omise-plugin/helpers/charge.php
+++ b/omise/libraries/omise-plugin/helpers/charge.php
@@ -1,0 +1,22 @@
+<?php
+if (! class_exists('OmisePluginHelperCharge')) {
+    class OmisePluginHelperCharge
+    {
+        /**
+         *
+         * @param string $currency
+         * @param integer $amount
+         * @return string
+         */
+        public static function amount($currency, $amount)
+        {
+            switch (strtoupper($currency)) {
+                case 'THB':
+                    $amount = $amount * 100;
+                    break;
+            }
+
+            return $amount;
+        }
+    }
+}

--- a/omise/setting.php
+++ b/omise/setting.php
@@ -42,6 +42,24 @@ class Setting
     }
 
     /**
+     * Return the secret key by checking whether
+     * the current setting for sandbox status is enabled or disabled.
+     *
+     * Return the TEST secret key, if the sandbox status is enabled (testing mode).
+     * Return the LIVE secret key, if the sandbox status is disabled (live mode).
+     *
+     * @return string
+     */
+    public function getSecretKey()
+    {
+        if ($this->isSandboxEnabled()) {
+            return $this->getTestSecretKey();
+        }
+
+        return $this->getLiveSecretKey();
+    }
+
+    /**
      * @return string
      */
     public function getSubmitAction()

--- a/omise/views/templates/front/payment_result.tpl
+++ b/omise/views/templates/front/payment_result.tpl
@@ -4,12 +4,12 @@
 
 <h2>{l s='Order result' mod='omise'}</h2>
 
-{if $payment_success == 'true'}
+{if $error_message}
   <p>
-    Payment Success
+    Payment Failed, {$error_message}
   </p>
 {else}
   <p>
-    Payment Failed, {$error_message}
+    Payment Success
   </p>
 {/if}

--- a/omise/views/templates/front/payment_result.tpl
+++ b/omise/views/templates/front/payment_result.tpl
@@ -1,0 +1,15 @@
+{capture name=path}
+    {l s='Order result' mod='omise'}
+{/capture}
+
+<h2>{l s='Order result' mod='omise'}</h2>
+
+{if $payment_success == 'true'}
+  <p>
+    Payment Success
+  </p>
+{else}
+  <p>
+    Payment Failed, {$error_message}
+  </p>
+{/if}

--- a/omise/views/templates/hook/payment.tpl
+++ b/omise/views/templates/hook/payment.tpl
@@ -7,7 +7,7 @@
             <h3>{$omise_title}</h3>
           </div>
           <div class="col-sm-8 col-md-5 col-lg-4">
-              <form id="omise_checkout_form">
+              <form id="omise_checkout_form" method="post" action="{$link->getModuleLink('omise', 'payment', [], true)|escape:'html'}">
                 <input id="omise_card_token" name="omise_card_token" type="hidden">
                 <div class="row">
                   <div class="form-group col-sm-12">
@@ -95,6 +95,7 @@
   const omiseCreateTokenCallback = function omiseCreateTokenCallback(statusCode, response) {
     if (statusCode === 200) {
       document.getElementById('omise_card_token').value = response.id;
+      document.getElementById('omise_checkout_form').submit();
     } else {
       alert(response.message);
       omiseUnlockCheckoutForm(omiseCheckoutForm);

--- a/tests/autoload.php
+++ b/tests/autoload.php
@@ -7,6 +7,7 @@ function autoload($class)
         $classes = array(
             'CheckoutForm' => 'checkout_form.php',
             'Omise' => 'omise.php',
+            'OmisePaymentModuleFrontController' => 'controllers/front/payment.php',
             'Setting' => 'setting.php',
         );
     }

--- a/tests/autoload.php
+++ b/tests/autoload.php
@@ -4,24 +4,3 @@ require_once __DIR__ . '/../vendor/autoload.php';
 if (! defined('_PS_VERSION_')) {
     define('_PS_VERSION_', 'TEST_VERSION');
 }
-
-function autoload($class)
-{
-    static $classes = null;
-
-    if ($classes === null) {
-        $classes = array(
-            'Charge' => 'classes/charge.php',
-            'CheckoutForm' => 'checkout_form.php',
-            'Omise' => 'omise.php',
-            'OmisePaymentModuleFrontController' => 'controllers/front/payment.php',
-            'Setting' => 'setting.php',
-        );
-    }
-
-    if (isset($classes[$class])) {
-        require __DIR__ . '/../omise/' . $classes[$class];
-    }
-}
-
-spl_autoload_register('autoload');

--- a/tests/autoload.php
+++ b/tests/autoload.php
@@ -1,6 +1,10 @@
 <?php
 require_once __DIR__ . '/../vendor/autoload.php';
 
+if (! defined('_PS_VERSION_')) {
+    define('_PS_VERSION_', 'TEST_VERSION');
+}
+
 function autoload($class)
 {
     static $classes = null;

--- a/tests/autoload.php
+++ b/tests/autoload.php
@@ -11,6 +11,7 @@ function autoload($class)
 
     if ($classes === null) {
         $classes = array(
+            'Charge' => 'classes/charge.php',
             'CheckoutForm' => 'checkout_form.php',
             'Omise' => 'omise.php',
             'OmisePaymentModuleFrontController' => 'controllers/front/payment.php',

--- a/tests/autoload.php
+++ b/tests/autoload.php
@@ -1,4 +1,6 @@
 <?php
+require_once __DIR__ . '/../vendor/autoload.php';
+
 function autoload($class)
 {
     static $classes = null;

--- a/tests/unit/CheckoutFormTest.php
+++ b/tests/unit/CheckoutFormTest.php
@@ -1,8 +1,4 @@
 <?php
-if (! defined('_PS_VERSION_')) {
-    define('_PS_VERSION_', 'TEST_VERSION');
-}
-
 class CheckoutFormTest extends PHPUnit_Framework_TestCase
 {
     private $list_of_expiration_year;

--- a/tests/unit/CheckoutFormTest.php
+++ b/tests/unit/CheckoutFormTest.php
@@ -1,4 +1,8 @@
 <?php
+if (! defined('_PS_VERSION_')) {
+    define('_PS_VERSION_', 'TEST_VERSION');
+}
+
 class CheckoutFormTest extends PHPUnit_Framework_TestCase
 {
     private $list_of_expiration_year;

--- a/tests/unit/OmiseTest.php
+++ b/tests/unit/OmiseTest.php
@@ -1,8 +1,4 @@
 <?php
-if (! defined('_PS_VERSION_')) {
-    define('_PS_VERSION_', 'TEST_VERSION');
-}
-
 class OmiseTest extends PHPUnit_Framework_TestCase
 {
     private $checkout_form;

--- a/tests/unit/classes/ChargeTest.php
+++ b/tests/unit/classes/ChargeTest.php
@@ -1,0 +1,86 @@
+<?php
+use \Mockery as m;
+
+class ChargeTest extends PHPUnit_Framework_TestCase
+{
+    private $charge;
+    private $secret_key = 'secretKey';
+
+    public function setup()
+    {
+        $this->getMockBuilder(get_class(new stdClass()))
+            ->setMockClassName('ModuleFrontController')
+            ->setMethods(
+                array(
+                    'initContent',
+                )
+            )
+            ->getMock();
+
+        $context = $this->createMock(get_class(new stdClass()));
+        $context->cart = new Cart();
+
+        $currency_instance = $this->createMock(get_class(new stdClass()));
+        $currency_instance->iso_code = 'THB';
+
+        m::mock('alias:\Currency')
+            ->shouldReceive('getCurrencyInstance')
+            ->with(1234)
+            ->andReturn($currency_instance);
+
+        m::mock('alias:\OmisePluginHelperCharge')
+            ->shouldReceive('amount')
+            ->andReturn(10025);
+
+        m::mock('overload:\Setting')
+            ->shouldReceive('getSecretKey')
+            ->andReturn($this->secret_key);
+
+        m::mock('alias:\Tools')
+            ->shouldReceive('getValue')
+            ->with('omise_card_token')
+            ->andReturn('cardToken');
+
+        $this->charge = new Charge();
+        $this->charge->context = $context;
+    }
+
+    public function testCreate_createOmiseCharge_createOnlyOneOmiseChargeWithCompleteRequestParameters()
+    {
+        m::mock('alias:\OmiseCharge')
+            ->shouldReceive('create')
+            ->with($this->createChargeRequest(), '', $this->secret_key)
+            ->once();
+
+        $this->charge->create();
+    }
+
+    private function createChargeRequest()
+    {
+        $charge_request = array(
+            'amount' => '10025',
+            'card' => 'cardToken',
+            'capture' => 'true',
+            'currency' => 'THB',
+            'description' => 'Charge a card using a token from PrestaShop (' . _PS_VERSION_ . ')',
+        );
+
+        return $charge_request;
+    }
+
+    public function tearDown() {
+        m::close();
+    }
+}
+
+class Cart
+{
+    const BOTH = 'both';
+
+    public $id_currency = 1234;
+
+    public function getOrderTotal($with_taxes, $type)
+    {
+        return '100.25';
+    }
+}

--- a/tests/unit/classes/ChargeTest.php
+++ b/tests/unit/classes/ChargeTest.php
@@ -17,10 +17,10 @@ class ChargeTest extends PHPUnit_Framework_TestCase
             )
             ->getMock();
 
-        $context = $this->createMock(get_class(new stdClass()));
+        $context = $this->getMockBuilder(get_class(new stdClass()));
         $context->cart = new Cart();
 
-        $currency_instance = $this->createMock(get_class(new stdClass()));
+        $currency_instance = $this->getMockBuilder(get_class(new stdClass()));
         $currency_instance->iso_code = 'THB';
 
         m::mock('alias:\Currency')

--- a/tests/unit/classes/ChargeTest.php
+++ b/tests/unit/classes/ChargeTest.php
@@ -45,6 +45,10 @@ class ChargeTest extends PHPUnit_Framework_TestCase
         $this->charge->context = $context;
     }
 
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
     public function testCreate_createOmiseCharge_createOnlyOneOmiseChargeWithCompleteRequestParameters()
     {
         m::mock('alias:\OmiseCharge')

--- a/tests/unit/classes/PaymentOrderTest.php
+++ b/tests/unit/classes/PaymentOrderTest.php
@@ -1,0 +1,102 @@
+<?php
+use \Mockery as m;
+
+class PaymentOrderTest extends PHPUnit_Framework_TestCase
+{
+    private $cart_id = 1234;
+    private $cart_order_total = 100.25;
+    private $currency_id = 12;
+    private $customer_id = 1;
+    private $customer_secure_key = 'customerSecureKey';
+    private $extra_variables = array();
+    private $is_not_needed_rounding_card_order_total = false;
+    private $module_display_name = 'Omise';
+    private $optional_message = null;
+    private $order_state_accepted_payment = 'orderStatusPayment';
+    private $payment_order;
+
+    public function setup()
+    {
+        $this->getMockBuilder(get_class(new stdClass()))
+            ->setMockClassName('ModuleFrontController')
+            ->setMethods(
+                array(
+                    '__construct',
+                    'initContent',
+                    'setTemplate',
+                )
+            )
+            ->getMock();
+
+        $cart = $this->getMockBuilder(get_class(new stdClass()))
+            ->setMethods(
+                array(
+                    'getOrderTotal',
+                )
+            )
+            ->getMock();
+        $cart->method('getOrderTotal')
+            ->willReturn($this->cart_order_total);
+        $cart->id = $this->cart_id;
+        $cart->id_customer = $this->customer_id;
+
+        $currency = $this->getMockBuilder(get_class(new stdClass()));
+        $currency->id = $this->currency_id;
+
+        $context = $this->getMockBuilder(get_class(new stdClass()));
+        $context->cart = $cart;
+        $context->currency = $currency;
+
+        m::mock('alias:\Configuration')
+            ->shouldReceive('get')
+            ->with('PS_OS_PAYMENT')
+            ->andReturn($this->order_state_accepted_payment);
+
+        $module = $this->getMockBuilder(get_class(new stdClass()))
+            ->setMethods(
+                array(
+                    'validateOrder',
+                )
+            )
+            ->getMock();
+        $module->displayName = $this->module_display_name;
+
+        $this->payment_order = new PaymentOrder();
+        $this->payment_order->context = $context;
+        $this->payment_order->module = $module;
+    }
+
+    public function testSave_saveTheOrder_onlyOneOrderHasBeenSaved()
+    {
+        $this->payment_order->module->expects($this->once())
+            ->method('validateOrder')
+            ->with($this->cart_id,
+                $this->order_state_accepted_payment,
+                $this->cart_order_total,
+                $this->module_display_name,
+                $this->optional_message,
+                $this->extra_variables,
+                $this->currency_id,
+                $this->is_not_needed_rounding_card_order_total,
+                $this->customer_secure_key
+            );
+
+        $this->payment_order->save();
+    }
+
+    public function tearDown()
+    {
+        m::close();
+    }
+}
+
+if (! class_exists('Customer')) {
+    class Customer
+    {
+        public $secure_key = 'customerSecureKey';
+
+        public function __construct($customerId)
+        {
+        }
+    }
+}

--- a/tests/unit/classes/PaymentOrderTest.php
+++ b/tests/unit/classes/PaymentOrderTest.php
@@ -11,6 +11,8 @@ class PaymentOrderTest extends PHPUnit_Framework_TestCase
     private $extra_variables = array();
     private $is_not_needed_rounding_card_order_total = false;
     private $module_display_name = 'Omise';
+    private $module_id = '2';
+    private $module_current_order = '3';
     private $optional_message = null;
     private $order_state_accepted_payment = 'orderStatusPayment';
     private $payment_order;
@@ -59,11 +61,27 @@ class PaymentOrderTest extends PHPUnit_Framework_TestCase
                 )
             )
             ->getMock();
+        $module->currentOrder = $this->module_current_order;
         $module->displayName = $this->module_display_name;
+        $module->id = $this->module_id;
 
         $this->payment_order = new PaymentOrder();
         $this->payment_order->context = $context;
         $this->payment_order->module = $module;
+    }
+
+    public function testRedirectToResultPage_redirectThePage_redirectTheSystemToTheOrderConfirmationPage()
+    {
+        m::mock('alias:Tools')
+            ->shouldReceive('redirect')
+            ->once()
+            ->with('index.php?controller=order-confirmation' .
+                '&id_cart=' . $this->cart_id .
+                '&id_module=' . $this->module_id .
+                '&id_order=' . $this->module_current_order .
+                '&key=' . $this->customer_secure_key);
+
+        $this->payment_order->redirectToResultPage();
     }
 
     public function testSave_saveTheOrder_onlyOneOrderHasBeenSaved()

--- a/tests/unit/controllers/OmisePaymentModuleFrontControllerTest.php
+++ b/tests/unit/controllers/OmisePaymentModuleFrontControllerTest.php
@@ -1,0 +1,107 @@
+<?php
+if (! defined('_PS_VERSION_')) {
+    define('_PS_VERSION_', 'TEST_VERSION');
+}
+
+if (! defined('_PS_MODULE_DIR_')) {
+    define('_PS_MODULE_DIR_', __DIR__ . '/../../..');
+}
+
+class OmisePaymentModuleFrontControllerTest extends PHPUnit_Framework_TestCase
+{
+    private $omisePaymentModuleFrontController;
+
+    public function setup()
+    {
+        $this->getMockBuilder(get_class(new stdClass()))
+            ->setMockClassName('ModuleFrontController')
+            ->getMock();
+
+        $this->getMockBuilder(get_class(new stdClass()))
+            ->setMockClassName('PaymentModule')
+            ->getMock();
+
+        $this->omisePaymentModuleFrontController = new OmisePaymentModuleFrontController();
+    }
+
+    public function testDisplayColumnLeft_displayTheResultPage_theLeftColumnWillNotAppear()
+    {
+        $this->assertFalse($this->omisePaymentModuleFrontController->display_column_left);
+    }
+
+    public function testGetCardToken_createOmiseCharge_getOmiseCardTokenFromClientSide()
+    {
+        \Mockery::mock('alias:\Tools')
+            ->shouldReceive('getValue')
+            ->with('omise_card_token')
+            ->andReturn('cardToken');
+
+        $card_token = $this->omisePaymentModuleFrontController->getCardToken();
+
+        $this->assertEquals('cardToken', $card_token);
+    }
+
+    public function testGetCapture_createOmiseCharge_captureIsTrue()
+    {
+        $this->assertEquals('true', $this->omisePaymentModuleFrontController->getCapture());
+    }
+
+    public function testGetChargeDescription_createOmiseCharge_validChargeDescription()
+    {
+        $validChargeDescription = 'Charge a card using a token from PrestaShop (' . _PS_VERSION_ . ')';
+
+        $chargeDescription = $this->omisePaymentModuleFrontController->getChargeDescription();
+
+        $this->assertEquals($validChargeDescription, $chargeDescription);
+    }
+
+    public function testGetCurrencyCode_createOmiseCharge_getCurrencyCodeFromCart()
+    {
+        $cart = $this->getMockBuilder(get_class(new stdClass()))
+            ->setMockClassName('Cart')
+            ->setMethods(
+                array(
+                    'getOrderTotal',
+                )
+            )
+            ->getMock();
+        $cart->id_currency = 1234;
+        $cart->method('getOrderTotal')->willReturn('123.45');
+
+        $context = $this->getMockBuilder(get_class(new stdClass()))
+            ->setMockClassName('Context')
+            ->getMock();
+        $context->cart = $cart;
+
+        $currency_instance = $this->getMockBuilder(get_class(new stdClass()))
+            ->setMockClassName('CurrencyInstance')
+            ->getMock();
+        $currency_instance->iso_code = 'THB';
+
+        \Mockery::mock('alias:\Currency')
+            ->shouldReceive('getCurrencyInstance')
+            ->with(1234)
+            ->andReturn($currency_instance);
+
+        $this->omisePaymentModuleFrontController->context = $context;
+
+        $currency_code = $this->omisePaymentModuleFrontController->getCurrencyCode();
+
+        $this->assertEquals('THB', $currency_code);
+    }
+
+    public function testGetSecretKey_createOmiseCharge_getSecretKeyFromSetting()
+    {
+        \Mockery::mock('alias:\Configuration')
+            ->shouldReceive('get')
+            ->with('sandbox_status')
+            ->andReturn(true)
+            ->shouldReceive('get')
+            ->with('test_secret_key')
+            ->andReturn('secretKey');
+
+        $secretKey = $this->omisePaymentModuleFrontController->getSecretKey();
+
+        $this->assertEquals('secretKey', $secretKey);
+    }
+}

--- a/tests/unit/controllers/OmisePaymentModuleFrontControllerTest.php
+++ b/tests/unit/controllers/OmisePaymentModuleFrontControllerTest.php
@@ -1,8 +1,4 @@
 <?php
-if (! defined('_PS_VERSION_')) {
-    define('_PS_VERSION_', 'TEST_VERSION');
-}
-
 if (! defined('_PS_MODULE_DIR_')) {
     define('_PS_MODULE_DIR_', __DIR__ . '/../../..');
 }

--- a/tests/unit/controllers/OmisePaymentModuleFrontControllerTest.php
+++ b/tests/unit/controllers/OmisePaymentModuleFrontControllerTest.php
@@ -28,7 +28,7 @@ class OmisePaymentModuleFrontControllerTest extends PHPUnit_Framework_TestCase
             )
             ->getMock();
 
-        $context = $this->createMock(get_class(new stdClass()));
+        $context = $this->getMockBuilder(get_class(new stdClass()));
         $context->smarty = $this->smarty;
 
         $this->omiseCharge = m::mock('overload:\Charge');
@@ -65,7 +65,7 @@ class OmisePaymentModuleFrontControllerTest extends PHPUnit_Framework_TestCase
 
     private function createSuccessOmiseChargeResult()
     {
-        $result = $this->createMock(get_class(new stdClass()));
+        $result = $this->getMockBuilder(get_class(new stdClass()));
         $result->object = 'charge';
 
         return $result;


### PR DESCRIPTION
#### 1. Objective

Implement function to save an order after created Omise charge.

**Related information**:
Related issue: -
Related ticket: T1147
Required pull request: #19 

#### 2. Description of change

- Add a new class, `PaymentOrder`, to save the order
- Implement a function that used to redirect the system to the result page
- Modify payment controller class, `OmisePaymentModuleFrontController`, to save an order and redirect to the result page

#### 3. Quality assurance

**Environments:**

- **Platform**: PrestaShop 1.6.1.6
- **Omise plugin**: Omise-PrestaShop 1.6.0.0
- **PHP**: 5.6.28
- **Mozilla Firefox**: 50.1.0

**Details:**

- Make sure that the Omise-PrestaShop has been installed and enabled.
- At the front-end, add a product to cart.
- Proceed to checkout.
- At the step, 05. Payment, fill the valid card information and click button, Submit Payment. The system will process the payment and display the result page.

The screenshot below shows a product that will be used to test.

![create_order](https://cloud.githubusercontent.com/assets/4145121/21763490/c0426a70-d690-11e6-92b4-2b0a869748ad.png)

The screenshot below shows the default result page of PrestaShop. After successfully created Omise charge and saved an order, the cart information will be cleared.

![cart_empty](https://cloud.githubusercontent.com/assets/4145121/21763528/e620a3f6-d690-11e6-9b74-cb99991b2290.png)

The screenshot below shows the saved order from the above payment at the _payer_ side.

![success_save_customer_side](https://cloud.githubusercontent.com/assets/4145121/21763600/39500706-d691-11e6-8302-a3c9f45378e2.png)

The screenshot below shows the saved order from the above payment at the _merchant_ side.

![success_save_merchant_side](https://cloud.githubusercontent.com/assets/4145121/21763612/45621908-d691-11e6-932c-0d80dabbbd40.png)

#### 4. Impact of the change

`-`

#### 5. Priority of change

Normal

#### 6. Additional notes

The result page still be the default of PrestaShop. It has no any information about the order. For the next pull request, the proper result page will be developed including error handling at the server side.

The screenshot below shows the [passed unit tests at Travis CI](https://travis-ci.org/nimid/omise-prestashop/builds/190196278).

![screenshot-travis-ci org 2017-01-09 16-54-45](https://cloud.githubusercontent.com/assets/4145121/21763749/0c967b9a-d692-11e6-875d-4cc9420cecdd.png)
