### PR TITLE
Create an Omise charge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .buildpath
 .project
 .settings/
+vendor/
+

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,5 @@
+{
+    "require-dev": {
+        "mockery/mockery": "dev-master"
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,9 @@
 {
     "require-dev": {
         "mockery/mockery": "dev-master"
+    },
+    "autoload": {
+        "classmap": ["omise/"],
+        "exclude-from-classmap": ["/omise/libraries/"]
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,134 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
+    ],
+    "hash": "293c33ec85fc878db8556281efb862ec",
+    "content-hash": "ead74161f1692cddf0294551ac9027fe",
+    "packages": [],
+    "packages-dev": [
+        {
+            "name": "hamcrest/hamcrest-php",
+            "version": "v2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/hamcrest/hamcrest-php.git",
+                "reference": "776503d3a8e85d4f9a1148614f95b7a608b046ad"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/hamcrest/hamcrest-php/zipball/776503d3a8e85d4f9a1148614f95b7a608b046ad",
+                "reference": "776503d3a8e85d4f9a1148614f95b7a608b046ad",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3|^7.0"
+            },
+            "replace": {
+                "cordoval/hamcrest-php": "*",
+                "davedevelopment/hamcrest-php": "*",
+                "kodova/hamcrest-php": "*"
+            },
+            "require-dev": {
+                "phpunit/php-file-iterator": "1.3.3",
+                "phpunit/phpunit": "~4.0",
+                "satooshi/php-coveralls": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "hamcrest"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD"
+            ],
+            "description": "This is the PHP port of Hamcrest Matchers",
+            "keywords": [
+                "test"
+            ],
+            "time": "2016-01-20 08:20:44"
+        },
+        {
+            "name": "mockery/mockery",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/padraic/mockery.git",
+                "reference": "d4f0db56642357c87e967beba75157fcdb9b0cca"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/padraic/mockery/zipball/d4f0db56642357c87e967beba75157fcdb9b0cca",
+                "reference": "d4f0db56642357c87e967beba75157fcdb9b0cca",
+                "shasum": ""
+            },
+            "require": {
+                "hamcrest/hamcrest-php": "~2.0",
+                "lib-pcre": ">=7.0",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Mockery": "library/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Pádraic Brady",
+                    "email": "padraic.brady@gmail.com",
+                    "homepage": "http://blog.astrumfutura.com"
+                },
+                {
+                    "name": "Dave Marshall",
+                    "email": "dave.marshall@atstsolutions.co.uk",
+                    "homepage": "http://davedevelopment.co.uk"
+                }
+            ],
+            "description": "Mockery is a simple yet flexible PHP mock object framework for use in unit testing with PHPUnit, PHPSpec or any other testing framework. Its core goal is to offer a test double framework with a succinct API capable of clearly defining all possible object operations and interactions using a human readable Domain Specific Language (DSL). Designed as a drop in alternative to PHPUnit's phpunit-mock-objects library, Mockery is easy to integrate with PHPUnit and can operate alongside phpunit-mock-objects without the World ending.",
+            "homepage": "http://github.com/padraic/mockery",
+            "keywords": [
+                "BDD",
+                "TDD",
+                "library",
+                "mock",
+                "mock objects",
+                "mockery",
+                "stub",
+                "test",
+                "test double",
+                "testing"
+            ],
+            "time": "2017-01-03 20:33:07"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {
+        "mockery/mockery": 20
+    },
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": []
+}

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "293c33ec85fc878db8556281efb862ec",
+    "hash": "bfd5ea2eba5f8e2ffb71bfa145500cc3",
     "content-hash": "ead74161f1692cddf0294551ac9027fe",
     "packages": [],
     "packages-dev": [
@@ -62,21 +62,21 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/padraic/mockery.git",
-                "reference": "d4f0db56642357c87e967beba75157fcdb9b0cca"
+                "reference": "e20e6dc435a9ef68fcf566dad8b232f170a1e3c1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/padraic/mockery/zipball/d4f0db56642357c87e967beba75157fcdb9b0cca",
-                "reference": "d4f0db56642357c87e967beba75157fcdb9b0cca",
+                "url": "https://api.github.com/repos/padraic/mockery/zipball/e20e6dc435a9ef68fcf566dad8b232f170a1e3c1",
+                "reference": "e20e6dc435a9ef68fcf566dad8b232f170a1e3c1",
                 "shasum": ""
             },
             "require": {
                 "hamcrest/hamcrest-php": "~2.0",
                 "lib-pcre": ">=7.0",
-                "php": ">=5.4.0"
+                "php": ">=5.6.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.0"
+                "phpunit/phpunit": "~5.7"
             },
             "type": "library",
             "extra": {
@@ -119,7 +119,7 @@
                 "test double",
                 "testing"
             ],
-            "time": "2017-01-03 20:33:07"
+            "time": "2017-02-16 08:49:25"
         }
     ],
     "aliases": [],

--- a/omise/classes/charge.php
+++ b/omise/classes/charge.php
@@ -1,0 +1,9 @@
+<?php
+if (! defined('_PS_VERSION_')) {
+    exit();
+}
+
+class Charge
+{
+
+}

--- a/omise/classes/charge.php
+++ b/omise/classes/charge.php
@@ -16,7 +16,7 @@ class Charge extends ModuleFrontController
         $charge_request = array(
             'amount' => $this->getAmount(),
             'card' => $this->getCardToken(),
-            'capture' => $this->getCapture(),
+            'capture' => 'true',
             'currency' => $this->getCurrencyCode(),
             'description' => $this->getChargeDescription(),
         );
@@ -35,11 +35,6 @@ class Charge extends ModuleFrontController
     protected function getCardToken()
     {
         return Tools::getValue('omise_card_token');
-    }
-
-    protected function getCapture()
-    {
-        return 'true';
     }
 
     protected function getChargeDescription()

--- a/omise/classes/charge.php
+++ b/omise/classes/charge.php
@@ -3,7 +3,47 @@ if (! defined('_PS_VERSION_')) {
     exit();
 }
 
+require_once _PS_MODULE_DIR_ . '/omise/libraries/omise-php/lib/Omise.php';
+require_once _PS_MODULE_DIR_ . '/omise/libraries/omise-plugin/Omise.php';
+require_once _PS_MODULE_DIR_ . '/omise/setting.php';
+
 class Charge extends ModuleFrontController
 {
+    public function getAmount()
+    {
+        $currency_code = $this->getCurrencyCode();
+        $order_total = (float) $this->context->cart->getOrderTotal(true, Cart::BOTH);
 
+        return OmisePluginHelperCharge::amount($currency_code, $order_total);
+    }
+
+    public function getCardToken()
+    {
+        return Tools::getValue('omise_card_token');
+    }
+
+    public function getCapture()
+    {
+        return 'true';
+    }
+
+    public function getChargeDescription()
+    {
+        return 'Charge a card using a token from PrestaShop (' . _PS_VERSION_ . ')';
+    }
+
+    public function getCurrencyCode()
+    {
+        $currency_id = (int) $this->context->cart->id_currency;
+        $currency_instance = Currency::getCurrencyInstance($currency_id);
+
+        return $currency_instance->iso_code;
+    }
+
+    public function getSecretKey()
+    {
+        $setting = new Setting();
+
+        return $setting->getSecretKey();
+    }
 }

--- a/omise/classes/charge.php
+++ b/omise/classes/charge.php
@@ -3,9 +3,11 @@ if (! defined('_PS_VERSION_')) {
     exit();
 }
 
-require_once _PS_MODULE_DIR_ . '/omise/libraries/omise-php/lib/Omise.php';
-require_once _PS_MODULE_DIR_ . '/omise/libraries/omise-plugin/Omise.php';
-require_once _PS_MODULE_DIR_ . '/omise/setting.php';
+if (defined('_PS_MODULE_DIR_')) {
+    require_once _PS_MODULE_DIR_ . '/omise/libraries/omise-php/lib/Omise.php';
+    require_once _PS_MODULE_DIR_ . '/omise/libraries/omise-plugin/Omise.php';
+    require_once _PS_MODULE_DIR_ . '/omise/setting.php';
+}
 
 class Charge extends ModuleFrontController
 {

--- a/omise/classes/charge.php
+++ b/omise/classes/charge.php
@@ -9,7 +9,7 @@ require_once _PS_MODULE_DIR_ . '/omise/setting.php';
 
 class Charge extends ModuleFrontController
 {
-    public function getAmount()
+    protected function getAmount()
     {
         $currency_code = $this->getCurrencyCode();
         $order_total = (float) $this->context->cart->getOrderTotal(true, Cart::BOTH);
@@ -17,22 +17,22 @@ class Charge extends ModuleFrontController
         return OmisePluginHelperCharge::amount($currency_code, $order_total);
     }
 
-    public function getCardToken()
+    protected function getCardToken()
     {
         return Tools::getValue('omise_card_token');
     }
 
-    public function getCapture()
+    protected function getCapture()
     {
         return 'true';
     }
 
-    public function getChargeDescription()
+    protected function getChargeDescription()
     {
         return 'Charge a card using a token from PrestaShop (' . _PS_VERSION_ . ')';
     }
 
-    public function getCurrencyCode()
+    protected function getCurrencyCode()
     {
         $currency_id = (int) $this->context->cart->id_currency;
         $currency_instance = Currency::getCurrencyInstance($currency_id);
@@ -40,7 +40,7 @@ class Charge extends ModuleFrontController
         return $currency_instance->iso_code;
     }
 
-    public function getSecretKey()
+    protected function getSecretKey()
     {
         $setting = new Setting();
 

--- a/omise/classes/charge.php
+++ b/omise/classes/charge.php
@@ -9,6 +9,19 @@ require_once _PS_MODULE_DIR_ . '/omise/setting.php';
 
 class Charge extends ModuleFrontController
 {
+    public function create()
+    {
+        $charge_request = array(
+            'amount' => $this->getAmount(),
+            'card' => $this->getCardToken(),
+            'capture' => $this->getCapture(),
+            'currency' => $this->getCurrencyCode(),
+            'description' => $this->getChargeDescription(),
+        );
+
+        return OmiseCharge::create($charge_request, '', $this->getSecretKey());
+    }
+
     protected function getAmount()
     {
         $currency_code = $this->getCurrencyCode();

--- a/omise/classes/charge.php
+++ b/omise/classes/charge.php
@@ -3,7 +3,7 @@ if (! defined('_PS_VERSION_')) {
     exit();
 }
 
-class Charge
+class Charge extends ModuleFrontController
 {
 
 }

--- a/omise/controllers/front/payment.php
+++ b/omise/controllers/front/payment.php
@@ -14,18 +14,10 @@ class OmisePaymentModuleFrontController extends ModuleFrontController
     {
         parent::initContent();
 
-        $charge_request = array(
-            'amount' => $this->getAmount(),
-            'card' => $this->getCardToken(),
-            'capture' => $this->getCapture(),
-            'currency' => $this->getCurrencyCode(),
-            'description' => $this->getChargeDescription(),
-        );
-
-        $secret_key = $this->getSecretKey();
+        $omiseCharge = new Charge();
 
         try {
-            $charge = OmiseCharge::create($charge_request, '', $secret_key);
+            $omiseCharge->create();
         } catch (Exception $e) {
             $this->context->smarty->assign('error_message', $e->getMessage());
         }

--- a/omise/controllers/front/payment.php
+++ b/omise/controllers/front/payment.php
@@ -1,0 +1,85 @@
+<?php
+if (! defined('_PS_VERSION_')) {
+    exit();
+}
+
+require_once _PS_MODULE_DIR_ . '/omise/libraries/omise-php/lib/Omise.php';
+require_once _PS_MODULE_DIR_ . '/omise/setting.php';
+
+class OmisePaymentModuleFrontController extends ModuleFrontController
+{
+    public $context;
+    public $display_column_left = false;
+
+    public function initContent()
+    {
+        parent::initContent();
+
+        $data = array(
+            'amount' => $this->getAmount(),
+            'card' => $this->getCardToken(),
+            'capture' => $this->getCapture(),
+            'currency' => $this->getCurrency(),
+            'description' => $this->getDescription(),
+        );
+
+        $secret_key = $this->getSecretKey();
+
+        try {
+            $charge = OmiseCharge::create($data, '', $secret_key);
+            $payment_success = true;
+        } catch (Exception $e) {
+            $payment_success = false;
+            $this->context->smarty->assign(
+                array(
+                    'error_message' => $e->getMessage(),
+                )
+            );
+        }
+
+        $this->context->smarty->assign(
+            array(
+                'payment_success' => $payment_success,
+            )
+        );
+
+        $this->setTemplate('payment_result.tpl');
+    }
+
+    public function getAmount()
+    {
+        $total = (float) $this->context->cart->getOrderTotal(true, Cart::BOTH);
+
+        return 100 * $total;
+    }
+
+    public function getCardToken()
+    {
+        return Tools::getValue('omise_card_token');
+    }
+
+    public function getCapture()
+    {
+        return 'true';
+    }
+
+    public function getCurrency()
+    {
+        $currency_id = (int) $this->context->cart->id_currency;
+        $currency_instance = Currency::getCurrencyInstance($currency_id);
+
+        return $currency_instance->iso_code;
+    }
+
+    public function getDescription()
+    {
+        return 'PrestaShop';
+    }
+
+    public function getSecretKey()
+    {
+        $setting = new Setting();
+
+        return $setting->getSecretKey();
+    }
+}

--- a/omise/controllers/front/payment.php
+++ b/omise/controllers/front/payment.php
@@ -3,10 +3,6 @@ if (! defined('_PS_VERSION_')) {
     exit();
 }
 
-require_once _PS_MODULE_DIR_ . '/omise/libraries/omise-php/lib/Omise.php';
-require_once _PS_MODULE_DIR_ . '/omise/libraries/omise-plugin/Omise.php';
-require_once _PS_MODULE_DIR_ . '/omise/setting.php';
-
 class OmisePaymentModuleFrontController extends ModuleFrontController
 {
     public $context;

--- a/omise/controllers/front/payment.php
+++ b/omise/controllers/front/payment.php
@@ -3,6 +3,8 @@ if (! defined('_PS_VERSION_')) {
     exit();
 }
 
+require_once _PS_MODULE_DIR_ . '/omise/classes/charge.php';
+
 class OmisePaymentModuleFrontController extends ModuleFrontController
 {
     public $context;

--- a/omise/controllers/front/payment.php
+++ b/omise/controllers/front/payment.php
@@ -9,7 +9,6 @@ if (defined('_PS_MODULE_DIR_')) {
 
 class OmisePaymentModuleFrontController extends ModuleFrontController
 {
-    public $context;
     public $display_column_left = false;
 
     public function initContent()

--- a/omise/controllers/front/payment.php
+++ b/omise/controllers/front/payment.php
@@ -34,42 +34,4 @@ class OmisePaymentModuleFrontController extends ModuleFrontController
 
         $this->setTemplate('payment_result.tpl');
     }
-
-    public function getAmount()
-    {
-        $currency_code = $this->getCurrencyCode();
-        $order_total = (float) $this->context->cart->getOrderTotal(true, Cart::BOTH);
-
-        return OmisePluginHelperCharge::amount($currency_code, $order_total);
-    }
-
-    public function getCardToken()
-    {
-        return Tools::getValue('omise_card_token');
-    }
-
-    public function getCapture()
-    {
-        return 'true';
-    }
-
-    public function getChargeDescription()
-    {
-        return 'Charge a card using a token from PrestaShop (' . _PS_VERSION_ . ')';
-    }
-
-    public function getCurrencyCode()
-    {
-        $currency_id = (int) $this->context->cart->id_currency;
-        $currency_instance = Currency::getCurrencyInstance($currency_id);
-
-        return $currency_instance->iso_code;
-    }
-
-    public function getSecretKey()
-    {
-        $setting = new Setting();
-
-        return $setting->getSecretKey();
-    }
 }

--- a/omise/controllers/front/payment.php
+++ b/omise/controllers/front/payment.php
@@ -3,7 +3,9 @@ if (! defined('_PS_VERSION_')) {
     exit();
 }
 
-require_once _PS_MODULE_DIR_ . '/omise/classes/charge.php';
+if (defined('_PS_MODULE_DIR_')) {
+    require_once _PS_MODULE_DIR_ . '/omise/classes/charge.php';
+}
 
 class OmisePaymentModuleFrontController extends ModuleFrontController
 {

--- a/omise/libraries/omise-plugin/Omise.php
+++ b/omise/libraries/omise-plugin/Omise.php
@@ -1,0 +1,2 @@
+<?php
+require_once dirname(__FILE__) . '/helpers/charge.php';

--- a/omise/libraries/omise-plugin/helpers/charge.php
+++ b/omise/libraries/omise-plugin/helpers/charge.php
@@ -1,0 +1,22 @@
+<?php
+if (! class_exists('OmisePluginHelperCharge')) {
+    class OmisePluginHelperCharge
+    {
+        /**
+         *
+         * @param string $currency
+         * @param integer $amount
+         * @return string
+         */
+        public static function amount($currency, $amount)
+        {
+            switch (strtoupper($currency)) {
+                case 'THB':
+                    $amount = $amount * 100;
+                    break;
+            }
+
+            return $amount;
+        }
+    }
+}

--- a/omise/setting.php
+++ b/omise/setting.php
@@ -42,6 +42,24 @@ class Setting
     }
 
     /**
+     * Return the secret key by checking whether
+     * the current setting for sandbox status is enabled or disabled.
+     *
+     * Return the TEST secret key, if the sandbox status is enabled (testing mode).
+     * Return the LIVE secret key, if the sandbox status is disabled (live mode).
+     *
+     * @return string
+     */
+    public function getSecretKey()
+    {
+        if ($this->isSandboxEnabled()) {
+            return $this->getTestSecretKey();
+        }
+
+        return $this->getLiveSecretKey();
+    }
+
+    /**
      * @return string
      */
     public function getSubmitAction()

--- a/omise/views/templates/front/payment_result.tpl
+++ b/omise/views/templates/front/payment_result.tpl
@@ -4,12 +4,12 @@
 
 <h2>{l s='Order result' mod='omise'}</h2>
 
-{if $payment_success == 'true'}
+{if $error_message}
   <p>
-    Payment Success
+    Payment Failed, {$error_message}
   </p>
 {else}
   <p>
-    Payment Failed, {$error_message}
+    Payment Success
   </p>
 {/if}

--- a/omise/views/templates/front/payment_result.tpl
+++ b/omise/views/templates/front/payment_result.tpl
@@ -1,0 +1,15 @@
+{capture name=path}
+    {l s='Order result' mod='omise'}
+{/capture}
+
+<h2>{l s='Order result' mod='omise'}</h2>
+
+{if $payment_success == 'true'}
+  <p>
+    Payment Success
+  </p>
+{else}
+  <p>
+    Payment Failed, {$error_message}
+  </p>
+{/if}

--- a/omise/views/templates/hook/payment.tpl
+++ b/omise/views/templates/hook/payment.tpl
@@ -7,7 +7,7 @@
             <h3>{$omise_title}</h3>
           </div>
           <div class="col-sm-8 col-md-5 col-lg-4">
-              <form id="omise_checkout_form">
+              <form id="omise_checkout_form" method="post" action="{$link->getModuleLink('omise', 'payment', [], true)|escape:'html'}">
                 <input id="omise_card_token" name="omise_card_token" type="hidden">
                 <div class="row">
                   <div class="form-group col-sm-12">
@@ -95,6 +95,7 @@
   const omiseCreateTokenCallback = function omiseCreateTokenCallback(statusCode, response) {
     if (statusCode === 200) {
       document.getElementById('omise_card_token').value = response.id;
+      document.getElementById('omise_checkout_form').submit();
     } else {
       alert(response.message);
       omiseUnlockCheckoutForm(omiseCheckoutForm);

--- a/tests/autoload.php
+++ b/tests/autoload.php
@@ -7,6 +7,7 @@ function autoload($class)
         $classes = array(
             'CheckoutForm' => 'checkout_form.php',
             'Omise' => 'omise.php',
+            'OmisePaymentModuleFrontController' => 'controllers/front/payment.php',
             'Setting' => 'setting.php',
         );
     }

--- a/tests/autoload.php
+++ b/tests/autoload.php
@@ -4,24 +4,3 @@ require_once __DIR__ . '/../vendor/autoload.php';
 if (! defined('_PS_VERSION_')) {
     define('_PS_VERSION_', 'TEST_VERSION');
 }
-
-function autoload($class)
-{
-    static $classes = null;
-
-    if ($classes === null) {
-        $classes = array(
-            'Charge' => 'classes/charge.php',
-            'CheckoutForm' => 'checkout_form.php',
-            'Omise' => 'omise.php',
-            'OmisePaymentModuleFrontController' => 'controllers/front/payment.php',
-            'Setting' => 'setting.php',
-        );
-    }
-
-    if (isset($classes[$class])) {
-        require __DIR__ . '/../omise/' . $classes[$class];
-    }
-}
-
-spl_autoload_register('autoload');

--- a/tests/autoload.php
+++ b/tests/autoload.php
@@ -1,6 +1,10 @@
 <?php
 require_once __DIR__ . '/../vendor/autoload.php';
 
+if (! defined('_PS_VERSION_')) {
+    define('_PS_VERSION_', 'TEST_VERSION');
+}
+
 function autoload($class)
 {
     static $classes = null;

--- a/tests/autoload.php
+++ b/tests/autoload.php
@@ -11,6 +11,7 @@ function autoload($class)
 
     if ($classes === null) {
         $classes = array(
+            'Charge' => 'classes/charge.php',
             'CheckoutForm' => 'checkout_form.php',
             'Omise' => 'omise.php',
             'OmisePaymentModuleFrontController' => 'controllers/front/payment.php',

--- a/tests/autoload.php
+++ b/tests/autoload.php
@@ -1,4 +1,6 @@
 <?php
+require_once __DIR__ . '/../vendor/autoload.php';
+
 function autoload($class)
 {
     static $classes = null;

--- a/tests/unit/CheckoutFormTest.php
+++ b/tests/unit/CheckoutFormTest.php
@@ -1,8 +1,4 @@
 <?php
-if (! defined('_PS_VERSION_')) {
-    define('_PS_VERSION_', 'TEST_VERSION');
-}
-
 class CheckoutFormTest extends PHPUnit_Framework_TestCase
 {
     private $list_of_expiration_year;

--- a/tests/unit/OmiseTest.php
+++ b/tests/unit/OmiseTest.php
@@ -1,8 +1,4 @@
 <?php
-if (! defined('_PS_VERSION_')) {
-    define('_PS_VERSION_', 'TEST_VERSION');
-}
-
 class OmiseTest extends PHPUnit_Framework_TestCase
 {
     private $checkout_form;

--- a/tests/unit/classes/ChargeTest.php
+++ b/tests/unit/classes/ChargeTest.php
@@ -1,0 +1,86 @@
+<?php
+use \Mockery as m;
+
+class ChargeTest extends PHPUnit_Framework_TestCase
+{
+    private $charge;
+    private $secret_key = 'secretKey';
+
+    public function setup()
+    {
+        $this->getMockBuilder(get_class(new stdClass()))
+            ->setMockClassName('ModuleFrontController')
+            ->setMethods(
+                array(
+                    'initContent',
+                )
+            )
+            ->getMock();
+
+        $context = $this->createMock(get_class(new stdClass()));
+        $context->cart = new Cart();
+
+        $currency_instance = $this->createMock(get_class(new stdClass()));
+        $currency_instance->iso_code = 'THB';
+
+        m::mock('alias:\Currency')
+            ->shouldReceive('getCurrencyInstance')
+            ->with(1234)
+            ->andReturn($currency_instance);
+
+        m::mock('alias:\OmisePluginHelperCharge')
+            ->shouldReceive('amount')
+            ->andReturn(10025);
+
+        m::mock('overload:\Setting')
+            ->shouldReceive('getSecretKey')
+            ->andReturn($this->secret_key);
+
+        m::mock('alias:\Tools')
+            ->shouldReceive('getValue')
+            ->with('omise_card_token')
+            ->andReturn('cardToken');
+
+        $this->charge = new Charge();
+        $this->charge->context = $context;
+    }
+
+    public function testCreate_createOmiseCharge_createOnlyOneOmiseChargeWithCompleteRequestParameters()
+    {
+        m::mock('alias:\OmiseCharge')
+            ->shouldReceive('create')
+            ->with($this->createChargeRequest(), '', $this->secret_key)
+            ->once();
+
+        $this->charge->create();
+    }
+
+    private function createChargeRequest()
+    {
+        $charge_request = array(
+            'amount' => '10025',
+            'card' => 'cardToken',
+            'capture' => 'true',
+            'currency' => 'THB',
+            'description' => 'Charge a card using a token from PrestaShop (' . _PS_VERSION_ . ')',
+        );
+
+        return $charge_request;
+    }
+
+    public function tearDown() {
+        m::close();
+    }
+}
+
+class Cart
+{
+    const BOTH = 'both';
+
+    public $id_currency = 1234;
+
+    public function getOrderTotal($with_taxes, $type)
+    {
+        return '100.25';
+    }
+}

--- a/tests/unit/classes/ChargeTest.php
+++ b/tests/unit/classes/ChargeTest.php
@@ -17,10 +17,10 @@ class ChargeTest extends PHPUnit_Framework_TestCase
             )
             ->getMock();
 
-        $context = $this->createMock(get_class(new stdClass()));
+        $context = $this->getMockBuilder(get_class(new stdClass()));
         $context->cart = new Cart();
 
-        $currency_instance = $this->createMock(get_class(new stdClass()));
+        $currency_instance = $this->getMockBuilder(get_class(new stdClass()));
         $currency_instance->iso_code = 'THB';
 
         m::mock('alias:\Currency')

--- a/tests/unit/classes/ChargeTest.php
+++ b/tests/unit/classes/ChargeTest.php
@@ -45,6 +45,10 @@ class ChargeTest extends PHPUnit_Framework_TestCase
         $this->charge->context = $context;
     }
 
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
     public function testCreate_createOmiseCharge_createOnlyOneOmiseChargeWithCompleteRequestParameters()
     {
         m::mock('alias:\OmiseCharge')

--- a/tests/unit/controllers/OmisePaymentModuleFrontControllerTest.php
+++ b/tests/unit/controllers/OmisePaymentModuleFrontControllerTest.php
@@ -1,0 +1,107 @@
+<?php
+if (! defined('_PS_VERSION_')) {
+    define('_PS_VERSION_', 'TEST_VERSION');
+}
+
+if (! defined('_PS_MODULE_DIR_')) {
+    define('_PS_MODULE_DIR_', __DIR__ . '/../../..');
+}
+
+class OmisePaymentModuleFrontControllerTest extends PHPUnit_Framework_TestCase
+{
+    private $omisePaymentModuleFrontController;
+
+    public function setup()
+    {
+        $this->getMockBuilder(get_class(new stdClass()))
+            ->setMockClassName('ModuleFrontController')
+            ->getMock();
+
+        $this->getMockBuilder(get_class(new stdClass()))
+            ->setMockClassName('PaymentModule')
+            ->getMock();
+
+        $this->omisePaymentModuleFrontController = new OmisePaymentModuleFrontController();
+    }
+
+    public function testDisplayColumnLeft_displayTheResultPage_theLeftColumnWillNotAppear()
+    {
+        $this->assertFalse($this->omisePaymentModuleFrontController->display_column_left);
+    }
+
+    public function testGetCardToken_createOmiseCharge_getOmiseCardTokenFromClientSide()
+    {
+        \Mockery::mock('alias:\Tools')
+            ->shouldReceive('getValue')
+            ->with('omise_card_token')
+            ->andReturn('cardToken');
+
+        $card_token = $this->omisePaymentModuleFrontController->getCardToken();
+
+        $this->assertEquals('cardToken', $card_token);
+    }
+
+    public function testGetCapture_createOmiseCharge_captureIsTrue()
+    {
+        $this->assertEquals('true', $this->omisePaymentModuleFrontController->getCapture());
+    }
+
+    public function testGetChargeDescription_createOmiseCharge_validChargeDescription()
+    {
+        $validChargeDescription = 'Charge a card using a token from PrestaShop (' . _PS_VERSION_ . ')';
+
+        $chargeDescription = $this->omisePaymentModuleFrontController->getChargeDescription();
+
+        $this->assertEquals($validChargeDescription, $chargeDescription);
+    }
+
+    public function testGetCurrencyCode_createOmiseCharge_getCurrencyCodeFromCart()
+    {
+        $cart = $this->getMockBuilder(get_class(new stdClass()))
+            ->setMockClassName('Cart')
+            ->setMethods(
+                array(
+                    'getOrderTotal',
+                )
+            )
+            ->getMock();
+        $cart->id_currency = 1234;
+        $cart->method('getOrderTotal')->willReturn('123.45');
+
+        $context = $this->getMockBuilder(get_class(new stdClass()))
+            ->setMockClassName('Context')
+            ->getMock();
+        $context->cart = $cart;
+
+        $currency_instance = $this->getMockBuilder(get_class(new stdClass()))
+            ->setMockClassName('CurrencyInstance')
+            ->getMock();
+        $currency_instance->iso_code = 'THB';
+
+        \Mockery::mock('alias:\Currency')
+            ->shouldReceive('getCurrencyInstance')
+            ->with(1234)
+            ->andReturn($currency_instance);
+
+        $this->omisePaymentModuleFrontController->context = $context;
+
+        $currency_code = $this->omisePaymentModuleFrontController->getCurrencyCode();
+
+        $this->assertEquals('THB', $currency_code);
+    }
+
+    public function testGetSecretKey_createOmiseCharge_getSecretKeyFromSetting()
+    {
+        \Mockery::mock('alias:\Configuration')
+            ->shouldReceive('get')
+            ->with('sandbox_status')
+            ->andReturn(true)
+            ->shouldReceive('get')
+            ->with('test_secret_key')
+            ->andReturn('secretKey');
+
+        $secretKey = $this->omisePaymentModuleFrontController->getSecretKey();
+
+        $this->assertEquals('secretKey', $secretKey);
+    }
+}

--- a/tests/unit/controllers/OmisePaymentModuleFrontControllerTest.php
+++ b/tests/unit/controllers/OmisePaymentModuleFrontControllerTest.php
@@ -1,8 +1,4 @@
 <?php
-if (! defined('_PS_VERSION_')) {
-    define('_PS_VERSION_', 'TEST_VERSION');
-}
-
 if (! defined('_PS_MODULE_DIR_')) {
     define('_PS_MODULE_DIR_', __DIR__ . '/../../..');
 }

--- a/tests/unit/controllers/OmisePaymentModuleFrontControllerTest.php
+++ b/tests/unit/controllers/OmisePaymentModuleFrontControllerTest.php
@@ -28,7 +28,7 @@ class OmisePaymentModuleFrontControllerTest extends PHPUnit_Framework_TestCase
             )
             ->getMock();
 
-        $context = $this->createMock(get_class(new stdClass()));
+        $context = $this->getMockBuilder(get_class(new stdClass()));
         $context->smarty = $this->smarty;
 
         $this->omiseCharge = m::mock('overload:\Charge');
@@ -65,7 +65,7 @@ class OmisePaymentModuleFrontControllerTest extends PHPUnit_Framework_TestCase
 
     private function createSuccessOmiseChargeResult()
     {
-        $result = $this->createMock(get_class(new stdClass()));
+        $result = $this->getMockBuilder(get_class(new stdClass()));
         $result->object = 'charge';
 
         return $result;


### PR DESCRIPTION
> Note1, original PR was made by @nimid at PR #14, #17, #16.
> This PR just did (and aimed to) rearrange those 3 PRs to make it easy to review by merging all those 3 PRs to only one, which is, this branch.
>
> Note2, this branch contains the same code at PR #16 (except, this branch already rebased with `develop`.

#### 1. Objective

Create an Omise charge by using the Omise card token that submitted from the client side.

**Related information**:
Related issue: -
Related ticket: -
Required pull request: #13 

#### 2. Description of change

- Add a helper class and a function, `OmisePluginHelperCharge.amount()` to format the charge amount for the Thai Baht currency.
- Complete the checkout form function to submit the Omise card token from client side to server side.
- Implement a class to process charge at server side.
- Add a dummy page for display the checkout result.

#### 3. Quality assurance

**Environments:**

- **Platform**: PrestaShop 1.6.1.6
- **Omise plugin**: Omise-PrestaShop 1.6.0.0
- **PHP**: 5.6.28
- **Mozilla Firefox**: 50.1.0

**Details:**

- Make sure that the Omise-PrestaShop has been installed and enabled.
- At the front-end, add a product to cart.
- Proceed to checkout.
- At the step, 05. Payment, fill the valid card information and click button, Submit Payment. The system will process the payment and display the result page.

The screenshot below shows the result page display the successful payment.

![screenshot-localhost 1616 2016-12-26 14-19-39](https://cloud.githubusercontent.com/assets/4145121/21478066/756c590a-cb7a-11e6-8dd3-4bc0f45f8eee.png)

The screenshot below shows charge detail at Omise dashboard. This charge was created from the above checkout.

![screenshot-dashboard omise co 2016-12-26 14-21-32](https://cloud.githubusercontent.com/assets/4145121/21478117/df71c678-cb7a-11e6-9905-ca6ff3d12c89.png)

#### 4. Impact of the change

`-`

#### 5. Priority of change

Normal

#### 6. Additional notes

For the next steps of charge process, such as record the order information to PrestaShop or display the proper result page, it will be developed for next pull request.