### PR TITLE
Modify the unit test, create mock object syntax, to support with PHP 5.4

### DIFF
--- a/tests/unit/OmiseTest.php
+++ b/tests/unit/OmiseTest.php
@@ -11,7 +11,7 @@ class OmiseTest extends PHPUnit_Framework_TestCase
 
     public function setup()
     {
-        $this->getMockBuilder(stdClass::class)
+        $this->getMockBuilder(get_class(new stdClass()))
             ->setMockClassName('PaymentModule')
             ->setMethods(
                 array(
@@ -23,7 +23,7 @@ class OmiseTest extends PHPUnit_Framework_TestCase
             )
             ->getMock();
 
-        $this->checkout_form = $this->getMockBuilder(CheckoutForm::class)
+        $this->checkout_form = $this->getMockBuilder(get_class(new CheckoutForm()))
             ->setMethods(
                 array(
                     'getListOfExpirationYear',
@@ -40,7 +40,7 @@ class OmiseTest extends PHPUnit_Framework_TestCase
             ->shouldReceive('isCurrentCurrencyApplicable')
             ->andReturn(true);
 
-        $this->setting = $this->getMockBuilder(Setting::class)
+        $this->setting = $this->getMockBuilder(get_class(new Setting()))
             ->setMethods(
                 array(
                     'getLivePublicKey',
@@ -59,7 +59,7 @@ class OmiseTest extends PHPUnit_Framework_TestCase
             )
             ->getMock();
 
-        $this->smarty = $this->getMockBuilder(stdClass::class)
+        $this->smarty = $this->getMockBuilder(get_class(new stdClass()))
             ->setMockClassName('Smarty')
             ->setMethods(
                 array(


### PR DESCRIPTION
> Note, original PR was introduced by @nimid at PR #15.
> This PR just did rebase #19 into the branch and then reopen it again. ([read here, for the reason](https://github.com/omise/omise-prestashop/pull/15#issuecomment-276611047))

> This PR required PR #19 to be merged first.

#### 1. Objective

Support running the unit test with PHP 5.4.

According to the [PrestaShop system requirements page](https://www.prestashop.com/en/system-requirements), it stated that the supported PHP version is from 5.4 onwards. To ensure that the source code is compatible with those PHP versions, it can be tested at the unit testing level as well.

But when run the unit testing with PHP 5.4, the error is `PHP Parse error:  syntax error, unexpected 'class' (T_CLASS), expecting identifier (T_STRING) or variable (T_VARIABLE) or '{' or '$' in /home/travis/build/nimid/omise-prestashop/tests/unit/OmiseTest.php on line 10`.

[The error only occurs with PHP 5.4](https://travis-ci.org/nimid/omise-prestashop/builds/187594636).

The error related with the `::class` syntax. [This syntax has been support since PHP 5.5](http://php.net/manual/en/language.oop5.basic.php#language.oop5.basic.class.class).

**Related information**:
Related issue: -
Related ticket: -

#### 2. Description of change

Changes the syntax that used to create mock object in part of unit testing. The syntax has been changed from the full class name reference to using the internal PHP function, [get_class](http://php.net/manual/en/function.get-class.php).

#### 3. Quality assurance

**Environments:**

- **Platform version**: - (This pull request did not change the base source code. Therefore, it is not required to test with platform.)
- **Omise plugin version**: Omise-PrestaShop 1.6.0.0
- **PHP versions**: 5.4, 5.5, 5.6, 7.0 and 7.1

**Details:**

**Manual testing**
Run the unit testing with PHPUnit (no additional required parameters).
For example:

```
$ phpunit
```

**Automated testing**
Setup the system such as Travis CI, CircleCI or Jenkins.

#### 4. Impact of the change

`-`

#### 5. Priority of change

Low

#### 6. Additional notes

The screenshot below shows the [error at Travis CI](https://travis-ci.org/nimid/omise-prestashop/jobs/187594637).

![error_on_travis_ci](https://cloud.githubusercontent.com/assets/4145121/21639579/672331a4-d2a3-11e6-90e0-26229133371e.png)

The screenshot below shows the [error at CircleCI](https://circleci.com/gh/nimid/omise-prestashop/24).

![error_on_circleci](https://cloud.githubusercontent.com/assets/4145121/21639640/ada214ba-d2a3-11e6-97b6-7e97d8d435cd.png)

The screenshot below shows the supported PHP version on PrestaShop system requirements page.

![screenshot-www prestashop com 2017-01-04 13-59-05](https://cloud.githubusercontent.com/assets/4145121/21639616/8eb41a44-d2a3-11e6-8ca1-9fdbe815ff98.png)