### PR TITLE
Save the Omise charge ID to PrestaShop order payment transaction ID for reference

### DIFF
--- a/omise/classes/payment_order.php
+++ b/omise/classes/payment_order.php
@@ -41,13 +41,23 @@ class PaymentOrder
     }
 
     /**
-     * The array of extra variables that will be used to attach to the order email.
+     * Return the array of extra variables.
+     *
+     * The extra variables will be used to save to database and attach to the order email.
+     *
+     * @param string $id_charge The Omise charge ID.
      *
      * @return array
      */
-    protected function getExtraVariables()
+    protected function getExtraVariables($id_charge)
     {
-        return array();
+        $extra_variables = array();
+
+        if (! empty($id_charge)) {
+            $extra_variables['transaction_id'] = $id_charge;
+        }
+
+        return $extra_variables;
     }
 
     protected function getModuleDisplayName()
@@ -109,7 +119,13 @@ class PaymentOrder
         return false;
     }
 
-    public function save($order_state = null)
+    /**
+     * Save an order to database by using PrestaShop core function.
+     *
+     * @param int $order_state
+     * @param string $id_charge The Omise charge ID.
+     */
+    public function save($order_state = null, $id_charge = null)
     {
         if (empty($order_state)) {
             $order_state = $this->getOrderStateAcceptedPayment();
@@ -121,7 +137,7 @@ class PaymentOrder
             $this->getCartOrderTotal(),
             $this->getModuleDisplayName(),
             $this->getOptionalMessage(),
-            $this->getExtraVariables(),
+            $this->getExtraVariables($id_charge),
             $this->getCurrencyId(),
             $this->isNotNeededRoundingCardOrderTotal(),
             $this->getCustomerSecureKey()

--- a/omise/classes/payment_order.php
+++ b/omise/classes/payment_order.php
@@ -150,6 +150,29 @@ class PaymentOrder
     }
 
     /**
+     * Update an order payment transaction ID to database.
+     *
+     * Note:
+     * - The PrestaShop order payment transaction ID has been mapped with Omise charge ID.
+     * - PrestaShop has order and order payment separate from each other. So, to update an order payment transaction ID,
+     * it need to retrieve the order payment from the order.
+     *
+     * @param int $id_order
+     * @param string $transaction_id The order payment transaction ID. It is the reference ID between PrestaShop order
+     * payment and Omise payment gateway.
+     */
+    public function updatePaymentTransactionId($id_order, $transaction_id)
+    {
+        $order = new Order($id_order);
+        $order_payment_collection = $order->getOrderPaymentCollection();
+
+        $order_payment = $order_payment_collection[0];
+
+        $order_payment->transaction_id = $transaction_id;
+        $order_payment->update();
+    }
+
+    /**
      * @param \Order $order The instance of class, Order.
      */
     public function updateStateToBeCanceled($order)

--- a/omise/controllers/front/internetbankingpayment.php
+++ b/omise/controllers/front/internetbankingpayment.php
@@ -23,6 +23,10 @@ class OmiseInternetBankingPaymentModuleFrontController extends OmiseBasePaymentM
             return;
         }
 
+        $id_order = Order::getOrderByCartId($this->context->cart->id);
+
+        $this->payment_order->updatePaymentTransactionId($id_order, $this->charge->getId());
+
         if ($this->charge->isFailed()) {
             $this->error_message = $this->charge->getErrorMessage();
             return;
@@ -32,7 +36,7 @@ class OmiseInternetBankingPaymentModuleFrontController extends OmiseBasePaymentM
             return;
         }
 
-        $this->addOmiseTransaction($this->charge->getId(), Order::getOrderByCartId($this->context->cart->id));
+        $this->addOmiseTransaction($this->charge->getId(), $id_order);
 
         $this->setRedirectAfter($this->charge->getAuthorizeUri());
     }

--- a/omise/controllers/front/payment.php
+++ b/omise/controllers/front/payment.php
@@ -19,7 +19,7 @@ class OmisePaymentModuleFrontController extends OmiseBasePaymentModuleFrontContr
             return;
         }
 
-        $this->payment_order->save();
+        $this->payment_order->save(null, $this->charge->getId());
 
         $this->setRedirectAfter('index.php?controller=order-confirmation' .
             '&id_cart=' . $this->context->cart->id .

--- a/omise/controllers/front/threedomainsecurepayment.php
+++ b/omise/controllers/front/threedomainsecurepayment.php
@@ -17,11 +17,14 @@ class OmiseThreeDomainSecurePaymentModuleFrontController extends OmiseBasePaymen
 
         parent::postProcess();
 
+        $id_order = Order::getOrderByCartId($this->context->cart->id);
+
         if (! empty($this->error_message)) {
             return;
         }
 
-        $this->addOmiseTransaction($this->charge->getId(), Order::getOrderByCartId($this->context->cart->id));
+        $this->payment_order->updatePaymentTransactionId($id_order, $this->charge->getId());
+        $this->addOmiseTransaction($this->charge->getId(), $id_order);
 
         $this->setRedirectAfter($this->charge->getAuthorizeUri());
     }

--- a/omise/controllers/front/threedomainsecurepayment.php
+++ b/omise/controllers/front/threedomainsecurepayment.php
@@ -19,11 +19,14 @@ class OmiseThreeDomainSecurePaymentModuleFrontController extends OmiseBasePaymen
 
         $id_order = Order::getOrderByCartId($this->context->cart->id);
 
+        if (! empty($this->charge)) {
+            $this->payment_order->updatePaymentTransactionId($id_order, $this->charge->getId());
+        }
+
         if (! empty($this->error_message)) {
             return;
         }
 
-        $this->payment_order->updatePaymentTransactionId($id_order, $this->charge->getId());
         $this->addOmiseTransaction($this->charge->getId(), $id_order);
 
         $this->setRedirectAfter($this->charge->getAuthorizeUri());

--- a/tests/unit/classes/PaymentOrderTest.php
+++ b/tests/unit/classes/PaymentOrderTest.php
@@ -116,7 +116,7 @@ class PaymentOrderTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($this->order_state_processing_in_progress, $order_state);
     }
 
-    public function testSave_theParameterOmiseChargeIdIsEmpty_noAnyOmiseChargeIdIsSavedToDatabaseForReference()
+    public function testSave_theParameterOmiseChargeIdIsEmpty_noAnyOmiseChargeIdSaveToDatabaseForReference()
     {
         $id_charge = '';
 
@@ -136,7 +136,7 @@ class PaymentOrderTest extends PHPUnit_Framework_TestCase
         $this->payment_order->save(null, $id_charge);
     }
 
-    public function testSave_theParameterOmiseChargeIdIsNull_noAnyOmiseChargeIdIsSavedToDatabaseForReference()
+    public function testSave_theParameterOmiseChargeIdIsNull_noAnyOmiseChargeIdIsSaveToDatabaseForReference()
     {
         $id_charge = null;
 

--- a/tests/unit/classes/PaymentOrderTest.php
+++ b/tests/unit/classes/PaymentOrderTest.php
@@ -116,6 +116,66 @@ class PaymentOrderTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($this->order_state_processing_in_progress, $order_state);
     }
 
+    public function testSave_theParameterOmiseChargeIdIsEmpty_noAnyOmiseChargeIdIsSavedToDatabaseForReference()
+    {
+        $id_charge = '';
+
+        $this->module->expects($this->once())
+            ->method('validateOrder')
+            ->with($this->cart_id,
+                $this->order_state_accepted_payment,
+                $this->cart_order_total,
+                $this->module_display_name,
+                $this->optional_message,
+                array(),
+                $this->currency_id,
+                $this->is_not_needed_rounding_card_order_total,
+                $this->customer_secure_key
+            );
+
+        $this->payment_order->save(null, $id_charge);
+    }
+
+    public function testSave_theParameterOmiseChargeIdIsNull_noAnyOmiseChargeIdIsSavedToDatabaseForReference()
+    {
+        $id_charge = null;
+
+        $this->module->expects($this->once())
+            ->method('validateOrder')
+            ->with($this->cart_id,
+                $this->order_state_accepted_payment,
+                $this->cart_order_total,
+                $this->module_display_name,
+                $this->optional_message,
+                array(),
+                $this->currency_id,
+                $this->is_not_needed_rounding_card_order_total,
+                $this->customer_secure_key
+            );
+
+        $this->payment_order->save(null, $id_charge);
+    }
+
+    public function testSave_theParameterOmiseChargeIdIsNotEmpty_saveAnOmiseChargeIdToDatabaseForReference()
+    {
+        $id_charge = 'id_charge';
+
+        $this->module->expects($this->once())
+            ->method('validateOrder')
+            ->with($this->cart_id,
+                $this->order_state_accepted_payment,
+                $this->cart_order_total,
+                $this->module_display_name,
+                $this->optional_message,
+                array('transaction_id' => $id_charge),
+                $this->currency_id,
+                $this->is_not_needed_rounding_card_order_total,
+                $this->customer_secure_key
+            );
+
+        $this->payment_order->save(null, $id_charge);
+    }
+
     public function testSave_theParameterOrderStateIsEmpty_onlyOneOrderHasBeenSaved()
     {
         $this->module->expects($this->once())

--- a/tests/unit/controllers/OmisePaymentModuleFrontControllerTest.php
+++ b/tests/unit/controllers/OmisePaymentModuleFrontControllerTest.php
@@ -20,9 +20,10 @@ class OmisePaymentModuleFrontControllerTest extends PHPUnit_Framework_TestCase
             ->getMock();
 
         $this->omise_payment_module_front_controller = new OmisePaymentModuleFrontController();
-        $this->omise_payment_module_front_controller->payment_order = $this->getMockedPaymentOrder();
+        $this->omise_payment_module_front_controller->charge = $this->getMockedCharge();
         $this->omise_payment_module_front_controller->context = $this->getMockedContext();
         $this->omise_payment_module_front_controller->module = $this->getMockedModule();
+        $this->omise_payment_module_front_controller->payment_order = $this->getMockedPaymentOrder();
     }
 
     public function testPostProcess_errorOccurred_noAnyOrderHasBeenSaved()
@@ -38,9 +39,24 @@ class OmisePaymentModuleFrontControllerTest extends PHPUnit_Framework_TestCase
     public function testPostProcess_noErrorOccurred_saveTheOrder()
     {
         $this->payment_order->expects($this->once())
-            ->method('save');
+            ->method('save')
+            ->with(null, $this->omise_payment_module_front_controller->charge->getId());
 
         $this->omise_payment_module_front_controller->postProcess();
+    }
+
+    private function getMockedCharge()
+    {
+        $charge = $this->getMockBuilder(get_class(new stdClass()))
+            ->setMethods(
+                array(
+                    'getAuthorizeUri',
+                    'getId',
+                )
+            )
+            ->getMock();
+
+        return $charge;
     }
 
     private function getMockedContext()

--- a/tests/unit/controllers/OmiseThreeDomainSecurePaymentModuleFrontControllerTest.php
+++ b/tests/unit/controllers/OmiseThreeDomainSecurePaymentModuleFrontControllerTest.php
@@ -38,6 +38,17 @@ class OmiseThreeDomainSecurePaymentModuleFrontControllerTest extends PHPUnit_Fra
         $this->omise_three_domain_secure_payment_module_front_controller->postProcess();
     }
 
+    public function testPostProcess_createThreeDomainSecureChargeAndNoErrorOccurred_updatePaymentTransactionId()
+    {
+        $this->omise_three_domain_secure_payment_module_front_controller->error_message = '';
+
+        $this->omise_three_domain_secure_payment_module_front_controller->payment_order
+            ->expects($this->once())
+            ->method('updatePaymentTransactionId');
+
+        $this->omise_three_domain_secure_payment_module_front_controller->postProcess();
+    }
+
     public function testPostProcess_createThreeDomainSecureChargeAndNoErrorOccurred_redirectToAuthorizeUri()
     {
         $this->omise_three_domain_secure_payment_module_front_controller->error_message = '';
@@ -91,6 +102,7 @@ class OmiseThreeDomainSecurePaymentModuleFrontControllerTest extends PHPUnit_Fra
             ->setMethods(
                 array(
                     'saveAsProcessing',
+                    'updatePaymentTransactionId',
                 )
             )
             ->getMock();

--- a/tests/unit/controllers/OmiseThreeDomainSecurePaymentModuleFrontControllerTest.php
+++ b/tests/unit/controllers/OmiseThreeDomainSecurePaymentModuleFrontControllerTest.php
@@ -13,8 +13,10 @@ class OmiseThreeDomainSecurePaymentModuleFrontControllerTest extends PHPUnit_Fra
             ->setMethods(
                 array(
                     '__construct',
+                    'addOmiseTransaction',
                     'postProcess',
                     'setRedirectAfter',
+                    'validateCart',
                 )
             )
             ->getMock();


### PR DESCRIPTION
#### 1. Objective

Make the PrestaShop order has a reference to the Omise charge.

**Related information**:
- Related issue: #24 
- Related ticket: -

#### 2. Description of change

Save an Omise charge ID to PrestaShop order payment transaction ID. The changing in this pull request has been applied to all current supported 3 payment methods:

1. Normal charge (non 3-D Secure)
2. 3-D Secure
3. Internet Banking

**Note:**
The response from Omise API already contained the Omise charge ID. So, to save an Omise charge ID to PrestaShop order payment transaction ID, it is not need to add more Omise charge retrieval.

#### 3. Quality assurance

**Environments:**

- **Platform**: PrestaShop 1.6.1.14
- **Omise plugin**: Omise-PrestaShop 1.1
- **Omise-PHP**: 2.6.0
- **PHP**: 5.6.30
- **Mozilla Firefox**: 54.0

**Details:**

**At the front-end**
- Checkout an order

**At the back-end**
- Go to **Orders**
- View the order that recently created from the above testing step

The screenshot below shows the **success** order detail at the back-end, it shows an Omise charge ID has been saved and displayed at the order payment transaction ID for the reference.

![screenshot-localhost 16114-2017-06-21-06-57-27](https://user-images.githubusercontent.com/4145121/27370579-5bb4ca0e-5687-11e7-8f72-b7667c0acaa6.png)

The screenshot below shows the **fail** order detail at the back-end, it shows an Omise charge ID has been saved and displayed at the order payment transaction ID for the reference.

![screenshot-localhost 16114-2017-06-21-14-18-30](https://user-images.githubusercontent.com/4145121/27371857-9cafad26-568c-11e7-8fbd-37482506bd37.png)

#### 4. Impact of the change

This change impact to the charge process for all current supported 3 payment methods.

1. Normal charge (non 3-D Secure)
2. 3-D Secure
3. Internet Banking

#### 5. Priority of change

Normal

#### 6. Additional notes

**Before change:**
At the back-end, order payment detail, the data at the transaction ID is empty. This cause the merchant can not know or refer which PrestaShop order that associate with Omise charge.

**After change:**
Now, the merchant can refer between PrestaShop order and Omise charge.