### PR TITLE
Update the order status to be canceled instead of remain it processing in progress

### DIFF
--- a/omise/controllers/front/threedomainsecurepayment.php
+++ b/omise/controllers/front/threedomainsecurepayment.php
@@ -24,6 +24,7 @@ class OmiseThreeDomainSecurePaymentModuleFrontController extends OmiseBasePaymen
         }
 
         if (! empty($this->error_message)) {
+            $this->payment_order->updateStateToBeCanceled(new Order($id_order));
             return;
         }
 

--- a/tests/unit/controllers/OmiseThreeDomainSecurePaymentModuleFrontControllerTest.php
+++ b/tests/unit/controllers/OmiseThreeDomainSecurePaymentModuleFrontControllerTest.php
@@ -73,6 +73,17 @@ class OmiseThreeDomainSecurePaymentModuleFrontControllerTest extends PHPUnit_Fra
         $this->omise_three_domain_secure_payment_module_front_controller->postProcess();
     }
 
+    public function testPostProcess_errorOccurredAfterProcess_updateOrderStateToBeCanceled()
+    {
+        $this->omise_three_domain_secure_payment_module_front_controller->error_message = 'errorMessage';
+
+        $this->omise_three_domain_secure_payment_module_front_controller->payment_order
+            ->expects($this->once())
+            ->method('updateStateToBeCanceled');
+
+        $this->omise_three_domain_secure_payment_module_front_controller->postProcess();
+    }
+
     private function getMockedCharge()
     {
         $charge = $this->getMockBuilder(get_class(new stdClass()))
@@ -105,6 +116,7 @@ class OmiseThreeDomainSecurePaymentModuleFrontControllerTest extends PHPUnit_Fra
                 array(
                     'saveAsProcessing',
                     'updatePaymentTransactionId',
+                    'updateStateToBeCanceled',
                 )
             )
             ->getMock();


### PR DESCRIPTION
#### 1. Objective

For the 3-D Secure payment, if charge is failed, update the order status to be **Canceled** instead of remain it **Processing in progress**.

**Related information**:
- Related issue(s): #25 
- Related ticket: -

#### 2. Description of change

At the 3-D Secure payment controller class, add a command to update the order status to be canceled, if it has an error from the Omise charge process.

#### 3. Quality assurance

**Environments:**

- **Platform**: PrestaShop 1.6.1.14
- **Omise plugin**: Omise-PrestaShop 1.1
- **Omise-PHP**: 2.6.0
- **PHP**: 5.6.30
- **Mozilla Firefox**: 54.0

**Details:**

**There are 2 test cases below.**
1. Test create failed 3-D Secure charge with the condition, Fail Pre-auth aka Invalid Security Code, expect that the order status is Canceled.

2. Test create failed 3-D Secure charge with the condition, Fail 3DS Card Enrollment, expect that the order status is Canceled.

**Prerequisite**

**At the back-end**
- Make sure that the public key and secret key is the keys from the Omise account that has been enabled 3-D Secure payment
- Enable 3-D Secure payment, by set the setting for `3-D Secure support` to `Yes`

The screenshot below shows the Omise configuration at the back-end. In the red box, it is the setting for 3-D Secure payment.

![screenshot-localhost 16114-2017-06-21-17-30-24](https://user-images.githubusercontent.com/4145121/27380100-15d53250-56a8-11e7-85e3-61e0b9dd22ad.png)

**Test case 1:**

**At the front-end**
- Checkout an order
- At the payment step, Omise payment form, use the card number from the [Omise testing](https://www.omise.co/api-testing) for Fail Pre-auth aka Invalid Security Code.

For an example, `4111 1111 1116 0001`.

The expectation is meet. The screenshot below shows the PrestaShop order detail at the back-end. The current order status is canceled. Note that in the red box, the transaction ID is Omise charge ID. The PrestaShop order status and Omise charge status are consistent.

![screenshot-localhost 16114-2017-06-21-18-11-08](https://user-images.githubusercontent.com/4145121/27381568-816a9cb2-56ad-11e7-92b7-f0c034c9b48c.png)

The screenshot below shows the Omise charge detail at the Omise dashboard.

![omise](https://user-images.githubusercontent.com/4145121/27381587-934e5a18-56ad-11e7-8404-1f09e6a8fe9c.jpg)

**Test case 2:**

**At the front-end**
- Checkout an order
- At the Omise payment form, use the card number from the [Omise testing](https://www.omise.co/api-testing) for Fail 3DS Card Enrollment.

For an example, `4111 1111 1115 0002`.

The expectation is meet. The screenshot below shows the PrestaShop order detail at the back-end. The current order status is canceled. Note that in the red box, the transaction ID is Omise charge ID. The PrestaShop order status and Omise charge status are consistent.

![screenshot-localhost 16114-2017-06-21-18-19-30](https://user-images.githubusercontent.com/4145121/27381794-591fd78a-56ae-11e7-8f68-80051892fbc2.png)

The screenshot below shows the Omise charge detail at the Omise dashboard.

![omise2](https://user-images.githubusercontent.com/4145121/27381803-64aec5e8-56ae-11e7-9c6c-50a1dcf8091a.jpg)

#### 4. Impact of the change

This change impacts to only one payment process, 3-D Secure payment.

#### 5. Priority of change

Normal

#### 6. Additional notes

`-`