### PR TITLE
Specify the software version to be the detailed request information on Omise dashboard

### DIFF
--- a/omise/controllers/front/base.php
+++ b/omise/controllers/front/base.php
@@ -10,6 +10,10 @@ if (defined('_PS_MODULE_DIR_')) {
     require_once _PS_MODULE_DIR_ . 'omise/setting.php';
 }
 
+if (! defined('OMISE_USER_AGENT_SUFFIX')) {
+    define('OMISE_USER_AGENT_SUFFIX', sprintf('OmisePrestaShop/%s PrestaShop/%s', Omise::MODULE_VERSION, _PS_VERSION_));
+}
+
 abstract class OmiseBasePaymentModuleFrontController extends ModuleFrontController
 {
     protected $charge;

--- a/omise/controllers/front/base.php
+++ b/omise/controllers/front/base.php
@@ -10,6 +10,14 @@ if (defined('_PS_MODULE_DIR_')) {
     require_once _PS_MODULE_DIR_ . 'omise/setting.php';
 }
 
+/**
+ * Specify the software version when sending the request to Omise API. The specified versions will be displayed at
+ * Omise dashboard.
+ *
+ * This constant is used to append to request header, User-Agent. The request is send by library, Omise PHP.
+ *
+ * @see OmiseApiResource::genOptions() The function in library, Omise PHP, that uses this constant.
+ */
 if (! defined('OMISE_USER_AGENT_SUFFIX')) {
     define('OMISE_USER_AGENT_SUFFIX', sprintf('OmisePrestaShop/%s PrestaShop/%s', Omise::MODULE_VERSION, _PS_VERSION_));
 }

--- a/tests/unit/controllers/OmiseBasePaymentModuleFrontControllerTest.php
+++ b/tests/unit/controllers/OmiseBasePaymentModuleFrontControllerTest.php
@@ -1,0 +1,64 @@
+<?php
+use \Mockery as m;
+
+class OmiseBasePaymentModuleFrontControllerTest extends PHPUnit_Framework_TestCase
+{
+    public function setup()
+    {
+        $this->getMockBuilder(get_class(new stdClass()))
+            ->setMockClassName('ModuleFrontController')
+            ->setMethods(
+                array(
+                    '__construct',
+                )
+            )
+            ->getMock();
+
+        $this->getMockBuilder(get_class(new stdClass()))
+            ->setMockClassName('PaymentModule')
+            ->setMethods(
+                array(
+                    '__construct',
+                )
+            )
+            ->getMock();
+
+        m::mock('alias:\OmiseChargeClass');
+        m::mock('alias:\OmiseTransactionModel');
+        m::mock('alias:\PaymentOrder');
+
+        $this->getMockBuilder('OmiseBasePaymentModuleFrontController')
+            ->getMockForAbstractClass();
+    }
+
+    /**
+      * @runInSeparateProcess
+      * @preserveGlobalState disabled
+      */
+    public function testOmiseUserAgentSuffix_beforeCreateOmiseCharge_omisePrestaShopVersionForOmiseUserAgentSuffixMustBeDefined()
+    {
+        $omise_prestashop_version = 'OmisePrestaShop/' . Omise::MODULE_VERSION;
+
+        $omise_user_agent_suffix = explode(' ', OMISE_USER_AGENT_SUFFIX);
+
+        $this->assertEquals($omise_prestashop_version, $omise_user_agent_suffix[0]);
+    }
+
+    /**
+      * @runInSeparateProcess
+      * @preserveGlobalState disabled
+      */
+    public function testOmiseUserAgentSuffix_beforeCreateOmiseCharge_prestaShopVersionForOmiseUserAgentSuffixMustBeDefined()
+    {
+        $prestashop_version = 'PrestaShop/' . _PS_VERSION_;
+
+        $omise_user_agent_suffix = explode(' ', OMISE_USER_AGENT_SUFFIX);
+
+        $this->assertEquals($prestashop_version, $omise_user_agent_suffix[1]);
+    }
+
+    public function tearDown()
+    {
+        m::close();
+    }
+}


### PR DESCRIPTION
#### 1. Objective

Specify the Omise PrestaShop version and PrestaShop version to be the detailed request information on Omise dashboard. (The request such as charge request.)

These information, Omise PrestaShop version and PrestaShop version, are useful, for examples, when technical problems occur, these information can help to identify the cause of problem easier or these information can be historical data that may be used as analytical data.

**Related information**:
- Related issue: -
- Related ticket: -

#### 2. Description of change

Define a constant, `OMISE_USER_AGENT_SUFFIX`. The value of constant is Omise PrestaShop version and PrestaShop version.

The constant has been defined for the front office part only. The back office part does not need this constant.

#### 3. Quality assurance

**Environments:**

- **Platform**: PrestaShop 1.6.1.17
- **Omise plugin**: Omise PrestaShop 1.2
- **PHP**: 5.6.31

**Details:**

**Before change**
The screenshot below shows the Omise dashboard. In the red box, the user agent information has only Omise PHP version.

![before-change-user-agent-has-only-omise-php-version](https://user-images.githubusercontent.com/4145121/31504303-3d629914-af9c-11e7-9798-cc02645e3697.png)

**After change**
The screenshot below shows the Omise dashboard. In the red box, the Omise PrestaShop version and PrestaShop version have been added to the user agent information.

![after-change-omise-prestashop-version-and-prestashop-version-have-been-added](https://user-images.githubusercontent.com/4145121/31504437-9ca7cc1e-af9c-11e7-96f5-74c1aeb60a0e.png)

#### 4. Impact of the change

`-`

#### 5. Priority of change

Normal

#### 6. Additional notes

More information about [user agent](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent).