### PR TITLE
Display payment option on PrestaShop 1.7

### DIFF
--- a/omise/setting.php
+++ b/omise/setting.php
@@ -179,4 +179,14 @@ class Setting
         Configuration::updateValue('omise_three_domain_secure_status', strval(Tools::getValue('three_domain_secure_status')));
         Configuration::updateValue('omise_internet_banking_status', strval(Tools::getValue('internet_banking_status')));
     }
+
+    /**
+     * @param string $title
+     *
+     * @return bool
+     */
+    public function saveTitle($title)
+    {
+        return Configuration::updateValue('omise_title', strval($title));
+    }
 }

--- a/tests/unit/SettingTest.php
+++ b/tests/unit/SettingTest.php
@@ -258,6 +258,30 @@ class SettingTest extends PHPUnit_Framework_TestCase
         $this->setting->save();
     }
 
+    public function testSaveTitle_saveTheTitle_titleHasBeenSaved()
+    {
+        m::mock('alias:\Configuration')
+            ->shouldReceive('updateValue')->with('omise_title', 'title')->once();
+
+        $this->setting->saveTitle('title');
+    }
+
+    public function testSaveTitle_saveTheTitleIsFail_false()
+    {
+        m::mock('alias:\Configuration')
+            ->shouldReceive('updateValue')->andReturn(false);
+
+        $this->assertFalse($this->setting->saveTitle('title'));
+    }
+
+    public function testSaveTitle_saveTheTitleIsSuccess_true()
+    {
+        m::mock('alias:\Configuration')
+            ->shouldReceive('updateValue')->andReturn(true);
+
+        $this->assertTrue($this->setting->saveTitle('title'));
+    }
+
     public function tearDown()
     {
         m::close();


### PR DESCRIPTION
#### 1. Objective

Display payment option on PrestaShop 1.7.

According to [PrestaShop 1.7 has introduced a new payment API](http://developers.prestashop.com/module/50-PaymentModules/index.html), the module need to be implemented by follows PrestaShop 1.7 new payment API.

**Related information**:
- Related issue: #28 
- Related ticket: -

#### 2. Description of change

- Define a new constant, `DEFAULT_CARD_PAYMENT_TITLE`. This constant stores the default title of card payment. The title is consistent with the PrestaShop payment title by adding prefix **Pay by**.

- Save the above constant value to the database at the installation step.
Due to latest module version (Omise PrestaShop 1.2), it has no default payment title. This change helps to prevent the payment method is empty by the situation that the merchant first install the module but did not configured the title.

- Register and implement `hookPaymentOptions()` to display the payment option.

#### 3. Quality assurance

**Environments:**

- **Platform**: PrestaShop 1.7.2.3
- **Omise plugin**: Omise PrestaShop 1.2
- **PHP**: 5.6.31

**Details:**

The screenshot below shows the PrestaShop 1.7 back office, Omise PrestaShop module setting page. After installing the module for the first time, the default payment title has default value.

![omise-prestashop-the-default-payment-title](https://user-images.githubusercontent.com/4145121/31823180-69cb5ede-b5d5-11e7-9ae6-8dd08a618bca.png)

After installed module successfully, enable the module and click Save, the button at the right bottom of setting page.

![enable-omise-prestashop](https://user-images.githubusercontent.com/4145121/31823322-01f12248-b5d6-11e7-95a5-cbb44babe751.png)

After enabled module, go to the front office and proceed the checkout.

The screenshot below shows the PrestaShop 1.7 front office at payment step. The module, Omise PrestaShop, is available (Pay by Credit / Debit Card).

![omise-prestashop-payment-option-on-prestashop-1 7](https://user-images.githubusercontent.com/4145121/31821546-b2d8a0c4-b5cf-11e7-8c18-33075b9fc0bb.png)

Note
The payment form will be developed in the next pull request.

#### 4. Impact of the change

After this pull request, the module can not be installed on PrestaShop 1.6 because declaring a namespace, `use PrestaShop\PrestaShop\Core\Payment\PaymentOption;`, [at the line](https://github.com/omise/omise-prestashop/compare/support-prestashop-1.7...display-payment-option?expand=1#diff-9b969693cd451a46a870fab6297af91dR6) in this pull request.

This namespace declaration cause the error at the PrestaShop 1.6 installation step because PrestaShop 1.6 has no the above class and namespace.

The screenshot below shows the error when install this pull request on PrestaShop 1.6. Although the upload step is success but the installation step is error. In the red box at the top left of image, it shows the PrestaShop 1.6.1.17.

![omise-prestashop-installation-error-on-prestashop-1 6](https://user-images.githubusercontent.com/4145121/31824555-899adf42-b5d9-11e7-9034-c4aafc582bca.png)

#### 5. Priority of change

Normal

#### 6. Additional notes

[Official guide for payment module develpment on PrestaShop 1.7](http://developers.prestashop.com/module/50-PaymentModules/index.html).