### PR TITLE
Display card payment form

### DIFF
--- a/omise/omise.php
+++ b/omise/omise.php
@@ -215,6 +215,7 @@ class Omise extends PaymentModule
         $payment_options = array();
 
         $payment_option = new PaymentOption();
+        $payment_option->setAdditionalInformation($this->displayPayment());
         $payment_option->setCallToActionText($this->setting->getTitle());
         $payment_options[] = $payment_option;
 

--- a/omise/omise.php
+++ b/omise/omise.php
@@ -134,10 +134,8 @@ class Omise extends PaymentModule
             return $this->displayInapplicablePayment();
         }
 
-        $this->smarty->assign('action', $this->getAction());
         $this->smarty->assign('list_of_expiration_year', $this->checkout_form->getListOfExpirationYear());
         $this->smarty->assign('omise_public_key', $this->setting->getPublicKey());
-        $this->smarty->assign('omise_title', $this->setting->getTitle());
 
         return $this->display(__FILE__, 'payment.tpl');
     }

--- a/omise/views/templates/hook/inapplicable_payment.tpl
+++ b/omise/views/templates/hook/inapplicable_payment.tpl
@@ -4,7 +4,6 @@
       <div class="box">
         <div class="row">
           <div class="col-sm-12">
-            <h3>{$omise_title}</h3>
             <div class="alert alert-danger">{l s='This payment method is not support for the current currency.' mod='omise'}</div>
           </div>
         </div>

--- a/omise/views/templates/hook/payment.tpl
+++ b/omise/views/templates/hook/payment.tpl
@@ -58,9 +58,6 @@
                 </div>
               </div>
             </form>
-            <button class="button btn btn-default standard-checkout button-medium" id="omise_checkout_button" onclick="omiseCheckout();">
-              <span id="omise_checkout_text">{l s='Submit Payment' mod='omise'}</span>
-            </button>
           </div>
         </div>
       </div>

--- a/omise/views/templates/hook/payment.tpl
+++ b/omise/views/templates/hook/payment.tpl
@@ -3,7 +3,7 @@
     <p class="payment_module">
       <div class="box">
         <div class="row">
-          <div class="col-sm-8 col-md-5 col-lg-4">
+          <div class="col-sm-12">
             <form id="omise_checkout_form" method="post">
               <input id="omise_card_token" name="omise_card_token" type="hidden">
               <div class="row">
@@ -19,7 +19,7 @@
                   </div>
               </div>
               <div class="row">
-                <div class="col-sm-5">
+                <div class="col-sm-6">
                   <div class="form-group">
                     <label for="omise_card_expiration_month">{l s='Expiration month' mod='omise'}</label>
                     <select class="form-control" id="omise_card_expiration_month">
@@ -38,7 +38,7 @@
                     </select>
                   </div>
                 </div>
-                <div class="col-xs-12 col-sm-5 pull-right">
+                <div class="col-sm-6 pull-right">
                   <div class="form-group">
                     <label for="omise_card_expiration_year">{l s='Expiration year' mod='omise'}</label>
                     <select class="form-control" id="omise_card_expiration_year">
@@ -48,7 +48,7 @@
                 </div>
               </div>
               <div class="row">
-                <div class="col-sm-5">
+                <div class="col-sm-6">
                   <div class="form-group">
                     <label for="omise_card_security_code">{l s='Security code' mod='omise'}</label>
                     <input class="form-control" id="omise_card_security_code" type="password" placeholder="{l s='Security code' mod='omise'}">

--- a/omise/views/templates/hook/payment.tpl
+++ b/omise/views/templates/hook/payment.tpl
@@ -3,8 +3,6 @@
     <p class="payment_module">
       <div class="box">
         <div class="row">
-          <div class="col-sm-12">
-          </div>
           <div class="col-sm-8 col-md-5 col-lg-4">
             <form id="omise_checkout_form" method="post">
               <input id="omise_card_token" name="omise_card_token" type="hidden">

--- a/omise/views/templates/hook/payment.tpl
+++ b/omise/views/templates/hook/payment.tpl
@@ -4,10 +4,9 @@
       <div class="box">
         <div class="row">
           <div class="col-sm-12">
-            <h3>{$omise_title}</h3>
           </div>
           <div class="col-sm-8 col-md-5 col-lg-4">
-            <form id="omise_checkout_form" method="post" action="{$action|escape:'html'}">
+            <form id="omise_checkout_form" method="post">
               <input id="omise_card_token" name="omise_card_token" type="hidden">
               <div class="row">
                 <div class="form-group col-sm-12">

--- a/tests/unit/OmiseTest.php
+++ b/tests/unit/OmiseTest.php
@@ -181,13 +181,11 @@ class OmiseTest extends PHPUnit_Framework_TestCase
         $this->checkout_form->method('getListOfExpirationYear')->willReturn('list_of_expiration_year');
         $this->omise->context->link->method('getModuleLink')->willReturn('payment');
 
-        $this->smarty->expects($this->exactly(4))
+        $this->smarty->expects($this->exactly(2))
             ->method('assign')
             ->withConsecutive(
-                array('action', 'payment'),
                 array('list_of_expiration_year', 'list_of_expiration_year'),
-                array('omise_public_key', 'omise_public_key'),
-                array('omise_title', 'title')
+                array('omise_public_key', 'omise_public_key')
             );
 
         $this->omise->hookPayment();

--- a/tests/unit/OmiseTest.php
+++ b/tests/unit/OmiseTest.php
@@ -240,14 +240,17 @@ class OmiseTest extends PHPUnit_Framework_TestCase
         $this->assertNull($payment_options);
     }
 
-    public function testHookPaymentOptions_moduleStatusIsEnabled_paymentOptionsIsNotNull()
+    public function testHookPaymentOptions_moduleStatusIsEnabled_displayCardPaymentOption()
     {
         $this->setting->method('isModuleEnabled')->willReturn(true);
+        m::mock('alias:\OmisePluginHelperCharge')
+            ->shouldReceive('isCurrentCurrencyApplicable')
+            ->andReturn(true);
+        $this->omise->method('display')->willReturn('payment');
 
         m::mock('overload:PrestaShop\PrestaShop\Core\Payment\PaymentOption')
-            ->shouldReceive('setCallToActionText')
-            ->once()
-            ->with($this->setting->getTitle());
+            ->shouldReceive('setAdditionalInformation')->with('payment')->once()
+            ->shouldReceive('setCallToActionText')->with($this->setting->getTitle())->once();
 
         $payment_options = $this->omise->hookPaymentOptions();
 


### PR DESCRIPTION
#### 1. Objective

Display card payment form.

**Related information**:
- Related issue: #28 
- Related ticket: -

#### 2. Description of change

- Display card payment form by using a PrestaShop 1.7 new API `setAdditionalInformation()` and reuse a function, `displayPayment()`, to be a parameter.

- Unassign 2 variables, `action` and `omise_title`, that were passed from controller to view. PrestaShop 1.7 has its own submit payment mechanism which payment module need to follow. So, the `action` will be unused.

    The title has been changed to display at the payment option instead. So, the `omise_title` displayed at the top of payment form is unnecessary and duplicated.

- Align the size of elements in card payment form to fit with its parent.

- Remove submit payment button. PrestaShop 1.7 has generated its own submit payment button. So, the submit payment button of module is unused.

#### 3. Quality assurance

**Environments:**

- **Platform**: PrestaShop 1.7.2.3
- **Omise plugin**: Omise PrestaShop 1.2
- **PHP**: 5.6.31

**Details:**

- At the back office, install and enable the module, if the module is not installed or enabled.
- Go to the front office and proceed the checkout.

The screenshot below shows the card payment form on PrestaShop 1.7.

![omise-prestashop-card-payment-form-on-prestashop-1 7](https://user-images.githubusercontent.com/4145121/31875097-ce96558a-b7f6-11e7-8e1c-ca1d6e295081.png)

The screenshot below shows the message when the customer checkout the order with unsupported currency such as USD.

![omise-prestashop-display-message-for-unsupport-currency](https://user-images.githubusercontent.com/4145121/31876415-be9eaf78-b7fc-11e7-91b6-456ec918d911.png)

#### 4. Impact of the change

`-`

#### 5. Priority of change

Normal

#### 6. Additional notes

`-`