### PR TITLE
Create Omise card token

### DIFF
--- a/omise/omise.php
+++ b/omise/omise.php
@@ -15,6 +15,18 @@ if (defined('_PS_MODULE_DIR_')) {
 class Omise extends PaymentModule
 {
     /**
+     * The name that used as the identifier of card payment option.
+     *
+     * A payment module can has more than one payment option. At the front office, each payment options can be
+     * identified by using module name (@see PaymentOption::setModuleName()).
+     *
+     * The module name is displayed at front office as an attribute of the payment option.
+     *
+     * @var string
+     */
+    const CARD_PAYMENT_OPTION_NAME = 'omise-card-payment';
+
+    /**
      * The default title of card payment.
      *
      * This constant will be saved to the database at the module installation step. (@see Omise::install())
@@ -215,6 +227,7 @@ class Omise extends PaymentModule
         $payment_option = new PaymentOption();
         $payment_option->setCallToActionText($this->setting->getTitle());
         $payment_option->setForm($this->displayPayment());
+        $payment_option->setModuleName(self::CARD_PAYMENT_OPTION_NAME);
         $payment_options[] = $payment_option;
 
         return $payment_options;

--- a/tests/unit/OmiseTest.php
+++ b/tests/unit/OmiseTest.php
@@ -248,7 +248,8 @@ class OmiseTest extends PHPUnit_Framework_TestCase
 
         m::mock('overload:PrestaShop\PrestaShop\Core\Payment\PaymentOption')
             ->shouldReceive('setCallToActionText')->with($this->setting->getTitle())->once()
-            ->shouldReceive('setForm')->with('payment')->once();
+            ->shouldReceive('setForm')->with('payment')->once()
+            ->shouldReceive('setModuleName')->with(Omise::CARD_PAYMENT_OPTION_NAME);
 
         $payment_options = $this->omise->hookPaymentOptions();
 


### PR DESCRIPTION
#### 1. Objective

Create Omise card token at the front office, client side.

The Omise card token will be submitted to server side to create Omise charge in the next step.

**Related information**:
- Related issue: #28 
- Related ticket: -

#### 2. Description of change

- Define a constant, `CARD_PAYMENT_OPTION_NAME`, at server side. This constant will be passed from server side to client side and will be assigned to be the identifier of card payment option.

- Modify JavaScript, client-side script, at the card payment form by add the action to the PrestaShop 1.7 generated submit payment button. The action is create Omise card token. It will be triggered, if the Omise card payment option has been selected.

  - Change all place that uses keyword `const` to `var` because `var` has more web browsers compatible than `const`.
  - Use JavaScript closure to reduce scope of functions and variables. Without JavaScript closure, the functions and variables may be altered by another unknown behavior or by mistake.

Note
The behavior of card payment form is similar to the before change. The behavior of card payment form after the user clicked submit payment button are:

- Lock the elements in card payment form to prevent the user change the information in card payment form after the user clicked submit payment button.
- Lock the submit payment button to prevent double submit payment by mistake or non mistake.
- Guide the user that the system is working after the user clicked submit payment button by change text of submit button to Processing.

#### 3. Quality assurance

**Environments:**

- **Platform**: PrestaShop 1.7.2.3
- **Omise plugin**: Omise PrestaShop 1.2
- **PHP**: 5.6.31
- **Web browsers**: Google Chrome 61.0, Mozilla Firefox 56.0.1, Opera 48.0, and Safari 11.0

**Details:**

There are 2 test cases.
1. Success case, test create Omise card token by using valid credit card information. The Omise card token must be created and assigned to the HTML element, hidden.
2. Fail case, test create Omise card token by using invalid credit card information. The error message must be displayed.

- At the PrestaShop back office, install and enable Omise payment module, if it is not installed and enabled.
- Go to the PrestaShop front office and proceed the checkout.
- At the payment step, input the valid test credit card information.

The screenshot below shows the testing on Google Chrome 61.0. The Omise card token has been created and assigned to the HTML element, hidden.

<img width="1280" alt="omise-prestashop-successfully-create-omise-card-token-on-google-chrome-61 0" src="https://user-images.githubusercontent.com/4145121/31973936-dc7ad4de-b952-11e7-8011-9dd1d823e2ec.png">

The screenshot below shows the testing on Mozilla Firefox 56.0.1. The Omise card token has been created and assigned to the HTML element, hidden.

<img width="1280" alt="omise-prestashop-successfully-create-omise-card-token-on-firefox-56 0 1" src="https://user-images.githubusercontent.com/4145121/31973946-e99e749a-b952-11e7-882a-6d98933b95d8.png">

The screenshot below shows the testing on Opera 48.0. The Omise card token has been created and assigned to the HTML element, hidden.

<img width="1280" alt="omise-prestashop-successfully-create-omise-card-token-on-opera-48 0" src="https://user-images.githubusercontent.com/4145121/31973950-f332380c-b952-11e7-8fd5-5fe2078136e5.png">

The screenshot below shows the testing on Safari 11.0. The Omise card token has been created and assigned to the HTML element, hidden.

<img width="1280" alt="omise-prestashop-successfully-create-omise-card-token-on-safari-11 0" src="https://user-images.githubusercontent.com/4145121/31973911-b3b9c974-b952-11e7-9a3b-1db672293630.png">

The screenshot below shows the error message when create Omise card token with invalid card number on Safari 11.0.

<img width="1280" alt="omise-prestashop-error-message-when-create-omise-card-token-with-invalid-credit-card-number" src="https://user-images.githubusercontent.com/4145121/31974226-8f97a14a-b954-11e7-88c4-7ba7a05a0d40.png">

#### 4. Impact of the change

`-`

#### 5. Priority of change

Normal

#### 6. Additional notes

References:
- [The table of web browsers that compatible with JavaScript keyword, `var`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/var#Browser_compatibility).
- [The table of web browsers that compatible with JavaScript keyword, `const`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/const#Browser_compatibility).