### PR TITLE
Remove unnecessary HTML <p> tag

### DIFF
--- a/omise/views/templates/hook/payment.tpl
+++ b/omise/views/templates/hook/payment.tpl
@@ -1,6 +1,5 @@
 <div class="row">
   <div class="col-xs-12">
-    <p class="payment_module">
       <div class="box">
         <div class="row">
           <div class="col-sm-12">
@@ -59,7 +58,6 @@
           </div>
         </div>
       </div>
-    </p>
   </div>
 </div>
 

--- a/omise/views/templates/hook/payment.tpl
+++ b/omise/views/templates/hook/payment.tpl
@@ -1,63 +1,63 @@
 <div class="row">
   <div class="col-xs-12">
-      <div class="box">
-        <div class="row">
-          <div class="col-sm-12">
-            <form id="omise_checkout_form" method="post">
-              <input id="omise_card_token" name="omise_card_token" type="hidden">
-              <div class="row">
-                <div class="form-group col-sm-12">
-                  <label for="omise_card_number">{l s='Card number' mod='omise'}</label>
-                  <input class="form-control" id="omise_card_number" type="text" placeholder="{l s='Card number' mod='omise'}">
+    <div class="box">
+      <div class="row">
+        <div class="col-sm-12">
+          <form id="omise_checkout_form" method="post">
+            <input id="omise_card_token" name="omise_card_token" type="hidden">
+            <div class="row">
+              <div class="form-group col-sm-12">
+                <label for="omise_card_number">{l s='Card number' mod='omise'}</label>
+                <input class="form-control" id="omise_card_number" type="text" placeholder="{l s='Card number' mod='omise'}">
+              </div>
+            </div>
+            <div class="row">
+              <div class="form-group col-sm-12">
+                <label for="omise_card_holder_name">{l s='Name on card' mod='omise'}</label>
+                <input class="form-control" id="omise_card_holder_name" type="text" placeholder="{l s='Name on card' mod='omise'}">
+              </div>
+            </div>
+            <div class="row">
+              <div class="col-sm-6">
+                <div class="form-group">
+                  <label for="omise_card_expiration_month">{l s='Expiration month' mod='omise'}</label>
+                  <select class="form-control" id="omise_card_expiration_month">
+                    <option value="01">01</option>
+                    <option value="02">02</option>
+                    <option value="03">03</option>
+                    <option value="04">04</option>
+                    <option value="05">05</option>
+                    <option value="06">06</option>
+                    <option value="07">07</option>
+                    <option value="08">08</option>
+                    <option value="09">09</option>
+                    <option value="10">10</option>
+                    <option value="11">11</option>
+                    <option value="12">12</option>
+                  </select>
                 </div>
               </div>
-              <div class="row">
-                <div class="form-group col-sm-12">
-                  <label for="omise_card_holder_name">{l s='Name on card' mod='omise'}</label>
-                  <input class="form-control" id="omise_card_holder_name" type="text" placeholder="{l s='Name on card' mod='omise'}">
+              <div class="col-sm-6 pull-right">
+                <div class="form-group">
+                  <label for="omise_card_expiration_year">{l s='Expiration year' mod='omise'}</label>
+                  <select class="form-control" id="omise_card_expiration_year">
+                    {html_options values=$list_of_expiration_year output=$list_of_expiration_year}
+                  </select>
                 </div>
               </div>
-              <div class="row">
-                <div class="col-sm-6">
-                  <div class="form-group">
-                    <label for="omise_card_expiration_month">{l s='Expiration month' mod='omise'}</label>
-                    <select class="form-control" id="omise_card_expiration_month">
-                      <option value="01">01</option>
-                      <option value="02">02</option>
-                      <option value="03">03</option>
-                      <option value="04">04</option>
-                      <option value="05">05</option>
-                      <option value="06">06</option>
-                      <option value="07">07</option>
-                      <option value="08">08</option>
-                      <option value="09">09</option>
-                      <option value="10">10</option>
-                      <option value="11">11</option>
-                      <option value="12">12</option>
-                    </select>
-                  </div>
-                </div>
-                <div class="col-sm-6 pull-right">
-                  <div class="form-group">
-                    <label for="omise_card_expiration_year">{l s='Expiration year' mod='omise'}</label>
-                    <select class="form-control" id="omise_card_expiration_year">
-                      {html_options values=$list_of_expiration_year output=$list_of_expiration_year}
-                    </select>
-                  </div>
+            </div>
+            <div class="row">
+              <div class="col-sm-6">
+                <div class="form-group">
+                  <label for="omise_card_security_code">{l s='Security code' mod='omise'}</label>
+                  <input class="form-control" id="omise_card_security_code" type="password" placeholder="{l s='Security code' mod='omise'}">
                 </div>
               </div>
-              <div class="row">
-                <div class="col-sm-6">
-                  <div class="form-group">
-                    <label for="omise_card_security_code">{l s='Security code' mod='omise'}</label>
-                    <input class="form-control" id="omise_card_security_code" type="password" placeholder="{l s='Security code' mod='omise'}">
-                  </div>
-                </div>
-              </div>
-            </form>
-          </div>
+            </div>
+          </form>
         </div>
       </div>
+    </div>
   </div>
 </div>
 


### PR DESCRIPTION
#### 1. Objective

Remove an invalid `<p>` tag in the card payment page. This `<p>` tag contains `<div>` tag which is invalid. It will causes an error when the debug mode has been activated.

This `<p>` tag does not affect the display. It does not have any CSS rules declared on it.

**Related information**:
- Related issue: -
- Related ticket: -

#### 2. Description of change

Remove an `<p>` tag and correct the indentation.

#### 3. Quality assurance

**Environments:**

- **Platform**: PrestaShop 1.7.2.3
- **Omise plugin**: Omise PrestaShop 1.2
- **PHP version**: 5.6.31
- **Web browser**: Safari 11.0

**Details:**

- Activate the debug mode at the PrestaShop back office.

Before change

The screenshot below shows an error at checkout page when debug mode has been activated.

![omise-prestashop-error-in-debug-mode-at-card-payment-page-invalid-p-tag](https://user-images.githubusercontent.com/4145121/32026933-7b228362-ba10-11e7-8dd0-135c9dba1e27.png)

After change

The screenshot below shows the checkout page. The page can be rendered and displayed normally.

![omise-prestashop-card-payment-form-on-prestashop-1 7](https://user-images.githubusercontent.com/4145121/32027159-ba121bfe-ba11-11e7-9bab-08b0ebd5b93a.png)

#### 4. Impact of the change

`-`

#### 5. Priority of change

Normal

#### 6. Additional notes

To activate debug mode in PrestaShop, it can be done by go to PrestaShop back office. From the left menu, go to CONFIGURE > Advanced Parameters > Performance > DEBUG MODE.

The screenshot below shows the debug mode configuration.

![prestashop-1 7-advanced-parameters-performance-debug-mode](https://user-images.githubusercontent.com/4145121/32027213-0745cbc8-ba12-11e7-9779-65e9ac9775d3.png)

After debug mode has been activated, PrestaShop will shows that the system is in debug mode from the left top indicator.

The screenshot below shows the indicator that PrestaShop is in debug bug mode.

![prestashop-1 7-debug-mode-has-been-activated](https://user-images.githubusercontent.com/4145121/32027307-870a1314-ba12-11e7-87f0-3d3820c73353.png)

Reference:
- [W3C `<p>` tag recommendation](https://www.w3.org/TR/html401/struct/text.html#h-9.3.1)

> The P element represents a paragraph. It cannot contain block-level elements (including P itself).