### PR TITLE
Create Omise charge

### DIFF
--- a/omise/controllers/front/base.php
+++ b/omise/controllers/front/base.php
@@ -71,7 +71,7 @@ abstract class OmiseBasePaymentModuleFrontController extends ModuleFrontControll
         $this->context->smarty->assign('error_message', $this->error_message);
         $this->context->smarty->assign('order_reference', $this->order_reference);
 
-        $this->setTemplate('payment-error.tpl');
+        $this->setTemplate('module:omise/views/templates/front/payment-error.tpl');
     }
 
     /**

--- a/omise/omise.php
+++ b/omise/omise.php
@@ -146,6 +146,7 @@ class Omise extends PaymentModule
             return $this->displayInapplicablePayment();
         }
 
+        $this->smarty->assign('action', $this->getAction());
         $this->smarty->assign('list_of_expiration_year', $this->checkout_form->getListOfExpirationYear());
         $this->smarty->assign('omise_public_key', $this->setting->getPublicKey());
 

--- a/omise/omise.php
+++ b/omise/omise.php
@@ -182,11 +182,11 @@ class Omise extends PaymentModule
             return;
         }
 
-        if ($params['objOrder']->module != $this->name) {
+        if ($params['order']->module != $this->name) {
             return;
         }
 
-        $this->smarty->assign('order_reference', $params['objOrder']->reference);
+        $this->smarty->assign('order_reference', $params['order']->reference);
 
         return $this->display(__FILE__, 'confirmation.tpl');
     }

--- a/omise/views/templates/front/payment-error.tpl
+++ b/omise/views/templates/front/payment-error.tpl
@@ -1,20 +1,30 @@
-{capture name=path}
-  {l s='Payment error' mod='omise'}
-{/capture}
+{extends file='page.tpl'}
 
-<h1 class="page-heading">{l s='Payment error' mod='omise'}</h1>
+{block name='page_content_container' prepend}
+  <section id="content" class="page-content page-order-confirmation card">
+    <div class="card-block">
+      <div class="row">
+        <div class="col-md-12">
 
-{assign var='current_step' value='payment'}
-{include file="$tpl_dir./order-steps.tpl"}
+          <aside id="notifications">
+            <div class="container">
+              <article class="alert alert-danger" role="alert" data-alert="danger">
+                <ul>
+                  <li>{$error_message}</li>
+                </ul>
+              </article>
+            </div>
+          </aside>
 
-<div class="alert alert-danger">
-  <p>{$error_message}</p>
-</div>
+          <div class="box order-confirmation">
+            {if ! empty($order_reference)}
+              <p>{l s='Your order reference is ' mod='omise'}<strong>{$order_reference}</strong>.</p>
+            {/if}
+            <p>{l s='The error occurred during process payment. Please contact our' mod='omise'} <a href="{$link->getPageLink('contact', true)|escape:'html':'UTF-8'}">{l s='customer support.' mod='omise'}</a></p>
+          </div>
 
-<div class="box order-confirmation">
-  {if ! empty($order_reference)}
-    {l s='Your order reference is ' mod='omise'}<strong>{$order_reference}</strong>.
-    <br />
-  {/if}
-  {l s='The error occurred during process payment. Please contact our' mod='omise'} <a href="{$link->getPageLink('contact', true)|escape:'html':'UTF-8'}">{l s='customer support.' mod='omise'}</a>
-</div>
+        </div>
+      </div>
+    </div>
+  </section>
+{/block}

--- a/omise/views/templates/front/payment-error.tpl
+++ b/omise/views/templates/front/payment-error.tpl
@@ -28,3 +28,6 @@
     </div>
   </section>
 {/block}
+
+{block name='page_content_container'}
+{/block}

--- a/omise/views/templates/hook/confirmation.tpl
+++ b/omise/views/templates/hook/confirmation.tpl
@@ -1,7 +1,4 @@
-<p class="alert alert-success">
-  {l s='Your order on %s has been received.' sprintf=$shop_name mod='omise'}
-</p>
 <div class="box order-confirmation">
-  {l s='Your order reference is ' mod='omise'}<strong>{$order_reference}</strong>.
-  <br />{l s='For any questions or for further information, please contact our' mod='omise'} <a href="{$link->getPageLink('contact', true)|escape:'html':'UTF-8'}">{l s='customer support.' mod='omise'}</a>
+  <p>{l s='Your order reference is ' mod='omise'}<strong>{$order_reference}</strong>.</p>
+  <p>{l s='For any questions or for further information, please contact our' mod='omise'} <a href="{$link->getPageLink('contact', true)|escape:'html':'UTF-8'}">{l s='customer support.' mod='omise'}</a></p>
 </div>

--- a/omise/views/templates/hook/payment.tpl
+++ b/omise/views/templates/hook/payment.tpl
@@ -3,7 +3,7 @@
     <div class="box">
       <div class="row">
         <div class="col-sm-12">
-          <form id="omise_checkout_form" method="post">
+          <form id="omise_checkout_form" method="post" action="{$action|escape:'html'}">
             <input id="omise_card_token" name="omise_card_token" type="hidden">
             <div class="row">
               <div class="form-group col-sm-12">
@@ -110,6 +110,7 @@
     var omiseCreateTokenCallback = function omiseCreateTokenCallback(statusCode, response) {
       if (statusCode === 200) {
         document.getElementById('omise_card_token').value = response.id;
+        document.getElementById('omise_checkout_form').submit();
       } else {
         alert(response.message);
         unlockOmiseCardPaymentForm(omiseCardPaymentForm);

--- a/tests/unit/OmiseTest.php
+++ b/tests/unit/OmiseTest.php
@@ -181,9 +181,10 @@ class OmiseTest extends PHPUnit_Framework_TestCase
         $this->checkout_form->method('getListOfExpirationYear')->willReturn('list_of_expiration_year');
         $this->omise->context->link->method('getModuleLink')->willReturn('payment');
 
-        $this->smarty->expects($this->exactly(2))
+        $this->smarty->expects($this->exactly(3))
             ->method('assign')
             ->withConsecutive(
+                array('action', 'payment'),
                 array('list_of_expiration_year', 'list_of_expiration_year'),
                 array('omise_public_key', 'omise_public_key')
             );


### PR DESCRIPTION
#### 1. Objective

Create Omise charge.

**Related information**:
- Related issue: #28 
- Related ticket: -

#### 2. Description of change

- Assign the action URL to `<form>` tag at client side and submit Omise card token to server side for create Omise charge, if the Omise card token has been successfully created at client side.
- Modify source code in part of `setTemplate()` and retrieve current order to use PrestaShop 1.7 new API.
- Modify 2 templates, to consistence with PrestaShop 1.7.
      1. Payment order confirmation (confirmation.tpl)
      2. Payment order error (payment-error.tpl)

#### 3. Quality assurance

**Environments:**

- **Platform**: PrestaShop 1.7.2.3
- **Omise plugin**: Omise PrestaShop 1.2
- **PHP version**: 5.6.31
- **Web browser**: Safari 11.0

**Details:**

There are 2 test cases.

1. Success case, create Omise charge and PrestaShop order are successful.
2. Failed case, create Omise charge and PrestaShop order are failed.

**Test case 1: Success case, create Omise charge and PrestaShop order are successful.**

- At the PrestaShop back office, install and enable Omise payment module, if it is not installed and enabled.
- Configure the public key and secret key.
- Go to the PrestaShop front office and proceed the checkout.
- At the payment step, input the valid test credit card information.

The screenshot below shows the result of success order. In the red box, the order reference is **RDKYDBGQL**.

![prestashop-1 7-successfully-create-omise-charge-and-prestashop-order](https://user-images.githubusercontent.com/4145121/32059314-f1354eec-ba95-11e7-9d09-758bd1b0b834.png)

The screenshot below shows PrestaShop back office, order detail. In the top red box, it shows the order reference is **RDKYDBGQL**. In the bottom red box, it shows the transaction ID (Omise charge ID).

![prestashop-back-office-order-detail](https://user-images.githubusercontent.com/4145121/32059554-b3ca5146-ba96-11e7-9a42-c407f3f2570e.png)

The screenshot below shows Omise dashboard, charge detail. This charge is the charge that created from the above step.

![omise-dashboard-charge-detail](https://user-images.githubusercontent.com/4145121/32059601-d05e7b7a-ba96-11e7-9eff-d62b1167ebe7.png)

**Test case 2: Failed case, create Omise charge and PrestaShop order are failed.**

- Go to the PrestaShop front office and proceed the checkout.
- At the payment step, input the INVALID test credit card information such as `4111 1111 1114 0011`. This card number is for test create Omise charge error, insufficient fund.

The screenshot below shows PrestaShop 1.7 front office. It displays the error message from the Omise API in case of create Omise charge is failed.

![prestashop-charge-error](https://user-images.githubusercontent.com/4145121/32059973-c2af773a-ba97-11e7-86d4-46e20c7cbf83.png)

The screenshot below shows Omise dashboard, charge detail. This charge is failed with the error, insufficient fund.

![omise-dashboard-create-charge-error-insufficient-fund](https://user-images.githubusercontent.com/4145121/32060365-b6a1f570-ba98-11e7-9533-207f305dae0c.png)

#### 4. Impact of the change

`-`

#### 5. Priority of change

Normal

#### 6. Additional notes

Reference:
- [Module Development Changes in PrestaShop 1.7, hook](http://build.prestashop.com/news/module-development-changes-in-17/#before)