### PR TITLE
Prevent popup of error notification at setting page in debug mode

### DIFF
--- a/omise/views/templates/admin/setting.tpl
+++ b/omise/views/templates/admin/setting.tpl
@@ -1,4 +1,4 @@
-{$confirmation}
+{if isset($confirmation)}{$confirmation}{/if}
 
 <form class="defaultForm form-horizontal" method="post">
   <div class="panel">


### PR DESCRIPTION
#### 1. Objective

Prevent the popup of error notification at setting page in debug mode.

**Related information**:
- Related issue: -
- Related ticket: -

#### 2. Description of change

Add a condition in setting page to check whether the confirmation message has been assigned from the server side to client side.

#### 3. Quality assurance

**Environments:**

- **Platform**: PrestaShop 1.7.2.3
- **Omise plugin**: Omise PrestaShop 1.2
- **PHP version**: 5.6.31

**Details:**

**Steps to reproduce:**

- Enable PrestaShop debug mode.
- Open the Omise module setting page by from the PrestaShop back office, left menu, goto IMPROVE > Modules > Modules & Services.

<img width="1280" alt="dashboard_ _omise_prestashop" src="https://user-images.githubusercontent.com/4145121/32133068-ac1e06f8-bbfa-11e7-914e-fc50a8376b9c.png">

- The Module selection page will be displayed. From the top menu, open Installed modules page.

<img width="1280" alt="module_selection_ _omise_prestashop" src="https://user-images.githubusercontent.com/4145121/32133071-b4422c60-bbfa-11e7-8c82-5b4ecbd462fb.png">

- The Omise module will be displayed. Click CONFIGURE.

<img width="1280" alt="manage_installed_modules_ _omise_prestashop" src="https://user-images.githubusercontent.com/4145121/32133072-c190a4c8-bbfa-11e7-9640-6c9556c73cbf.png">

**Before change:**

The screenshot below shows the popup of error message at setting page when the merchant open setting page in debug mode.

![undefined-variable-confirmation](https://user-images.githubusercontent.com/4145121/32132983-a1f92592-bbf8-11e7-90b8-059c33d89b0d.png)

**After change:**

It has no popup of error message when open the setting page in debug mode.

![omise-prestashop-setting-page-in-debug-mode](https://user-images.githubusercontent.com/4145121/32133090-3803263a-bbfb-11e7-8259-0a34a2da2d91.png)

#### 4. Impact of the change

`-`

#### 5. Priority of change

Normal

#### 6. Additional notes

This problem is not occurred in normal mode.