### PR TITLE
Create Omise internet banking charge

### DIFF
--- a/omise/controllers/front/internetbankingpayment.php
+++ b/omise/controllers/front/internetbankingpayment.php
@@ -23,7 +23,7 @@ class OmiseInternetBankingPaymentModuleFrontController extends OmiseBasePaymentM
             return;
         }
 
-        $id_order = Order::getOrderByCartId($this->context->cart->id);
+        $id_order = Order::getIdByCartId($this->context->cart->id);
 
         $this->payment_order->updatePaymentTransactionId($id_order, $this->charge->getId());
 

--- a/omise/omise.php
+++ b/omise/omise.php
@@ -234,6 +234,7 @@ class Omise extends PaymentModule
     {
         if ($this->setting->isInternetBankingEnabled()) {
             $this->context->controller->addCSS($this->_path . 'css/omise_internet_banking.css', 'all');
+            $this->context->controller->addJqueryPlugin('fancybox.js');
         }
     }
 

--- a/omise/views/templates/hook/internet_banking_payment.tpl
+++ b/omise/views/templates/hook/internet_banking_payment.tpl
@@ -61,8 +61,29 @@
   </div>
 </div>
 
+<div id="omise-message" hidden="hidden">
+  <p class="fancybox-error">{l s='Please select a bank before continuing.' js=1 mod='omise'}</p>
+</div>
+
 <script>
   (function() {
+    var omiseDisplayMessage = function omiseDisplayMessage(message) {
+      if ($.prototype.fancybox) {
+        $.fancybox.open([
+            {
+              type: 'inline',
+              autoScale: true,
+              minHeight: 30,
+              content: $('#omise-message').html(),
+            }],
+          {
+            padding: 0,
+          });
+      } else {
+        alert(message);
+      }
+    };
+
     var omiseHasAnyBankSelected = function omiseHasAnyBankSelected() {
       var selectedBank = document.getElementsByName('offsite');
 
@@ -94,6 +115,7 @@
           event.stopPropagation();
 
           if (omiseHasAnyBankSelected() == false) {
+            omiseDisplayMessage('{l s='Please select a bank before continuing.' js=1 mod='omise'}');
             return false;
           }
 

--- a/omise/views/templates/hook/internet_banking_payment.tpl
+++ b/omise/views/templates/hook/internet_banking_payment.tpl
@@ -60,3 +60,46 @@
     </div>
   </div>
 </div>
+
+<script>
+  (function() {
+    var omiseHasAnyBankSelected = function omiseHasAnyBankSelected() {
+      var selectedBank = document.getElementsByName('offsite');
+
+      for (var i = 0; i < selectedBank.length; i++) {
+        if (selectedBank[i].checked == true) {
+          return true;
+        }
+      }
+
+      return false;
+    };
+
+    var isOmiseInternetBankingOptionSelected = function isOmiseInternetBankingOptionSelected() {
+      var omiseInternetBankingOption = document.querySelector('[data-module-name="omise-internet-banking-payment"]');
+
+      if (omiseInternetBankingOption.checked) {
+        return true;
+      }
+
+      return false;
+    };
+
+    document.addEventListener('DOMContentLoaded', function () {
+      var paymentConfirmationButton = document.getElementById('payment-confirmation').getElementsByTagName('button')[0];
+
+      paymentConfirmationButton.addEventListener('click', function (event) {
+        if (isOmiseInternetBankingOptionSelected()) {
+          event.preventDefault();
+          event.stopPropagation();
+
+          if (omiseHasAnyBankSelected() == false) {
+            return false;
+          }
+
+          document.getElementById('omiseInternetBankingCheckoutForm').submit();
+        }
+      });
+    });
+  })();
+</script>

--- a/omise/views/templates/hook/internet_banking_payment.tpl
+++ b/omise/views/templates/hook/internet_banking_payment.tpl
@@ -3,11 +3,11 @@
     <div class="box">
       <div class="row">
         <div class="col-sm-12">
-          <form id="omiseInternetBankingCheckoutForm" method="post" action="{$link->getModuleLink('omise', 'internetbankingpayment', [], true)|escape:'html'}">
+          <form id="omise-internet-banking-payment-form" method="post" action="{$link->getModuleLink('omise', 'internetbankingpayment', [], true)|escape:'html'}">
             <ul class="omise-internet-banking">
               <li class="item">
-                <input class="no-uniform" id="omiseInternetBankingScb" name="offsite" type="radio" value="internet_banking_scb" autocomplete="off">
-                <label for="omiseInternetBankingScb">
+                <input class="no-uniform" id="omise-internet-banking-scb" name="offsite" type="radio" value="internet_banking_scb" autocomplete="off">
+                <label for="omise-internet-banking-scb">
                   <div class="omise-logo-wrapper scb">
                     <img src="/modules/omise/img/scb.svg" class="scb">
                   </div>
@@ -18,8 +18,8 @@
                 </label>
               </li>
               <li class="item">
-                <input class="no-uniform" id="omiseInternetBankingKtb" name="offsite" type="radio" value="internet_banking_ktb" autocomplete="off">
-                <label for="omiseInternetBankingKtb">
+                <input class="no-uniform" id="omise-internet-banking-ktb" name="offsite" type="radio" value="internet_banking_ktb" autocomplete="off">
+                <label for="omise-internet-banking-ktb">
                   <div class="omise-logo-wrapper ktb">
                     <img src="/modules/omise/img/ktb.svg" class="ktb">
                   </div>
@@ -30,8 +30,8 @@
                 </label>
               </li>
               <li class="item">
-                <input class="no-uniform" id="omiseInternetBankingBay" name="offsite" type="radio" value="internet_banking_bay" autocomplete="off">
-                <label for="omiseInternetBankingBay">
+                <input class="no-uniform" id="omise-internet-banking-bay" name="offsite" type="radio" value="internet_banking_bay" autocomplete="off">
+                <label for="omise-internet-banking-bay">
                   <div class="omise-logo-wrapper bay">
                     <img src="/modules/omise/img/bay.svg" class="bay">
                   </div>
@@ -42,8 +42,8 @@
                 </label>
               </li>
               <li class="item">
-                <input class="no-uniform" id="omiseInternetBankingBbl" name="offsite" type="radio" value="internet_banking_bbl" autocomplete="off">
-                <label for="omiseInternetBankingBbl">
+                <input class="no-uniform" id="omise-internet-banking-bbl" name="offsite" type="radio" value="internet_banking_bbl" autocomplete="off">
+                <label for="omise-internet-banking-bbl">
                   <div class="omise-logo-wrapper bbl">
                     <img src="/modules/omise/img/bbl.svg" class="bbl">
                   </div>
@@ -119,7 +119,7 @@
             return false;
           }
 
-          document.getElementById('omiseInternetBankingCheckoutForm').submit();
+          document.getElementById('omise-internet-banking-payment-form').submit();
         }
       });
     });

--- a/omise/views/templates/hook/internet_banking_payment.tpl
+++ b/omise/views/templates/hook/internet_banking_payment.tpl
@@ -6,7 +6,7 @@
           <form id="omise-internet-banking-payment-form" method="post" action="{$link->getModuleLink('omise', 'internetbankingpayment', [], true)|escape:'html'}">
             <ul class="omise-internet-banking">
               <li class="item">
-                <input class="no-uniform" id="omise-internet-banking-scb" name="offsite" type="radio" value="internet_banking_scb" autocomplete="off">
+                <input id="omise-internet-banking-scb" name="offsite" type="radio" value="internet_banking_scb" autocomplete="off">
                 <label for="omise-internet-banking-scb">
                   <div class="omise-logo-wrapper scb">
                     <img src="/modules/omise/img/scb.svg" class="scb">
@@ -18,7 +18,7 @@
                 </label>
               </li>
               <li class="item">
-                <input class="no-uniform" id="omise-internet-banking-ktb" name="offsite" type="radio" value="internet_banking_ktb" autocomplete="off">
+                <input id="omise-internet-banking-ktb" name="offsite" type="radio" value="internet_banking_ktb" autocomplete="off">
                 <label for="omise-internet-banking-ktb">
                   <div class="omise-logo-wrapper ktb">
                     <img src="/modules/omise/img/ktb.svg" class="ktb">
@@ -30,7 +30,7 @@
                 </label>
               </li>
               <li class="item">
-                <input class="no-uniform" id="omise-internet-banking-bay" name="offsite" type="radio" value="internet_banking_bay" autocomplete="off">
+                <input id="omise-internet-banking-bay" name="offsite" type="radio" value="internet_banking_bay" autocomplete="off">
                 <label for="omise-internet-banking-bay">
                   <div class="omise-logo-wrapper bay">
                     <img src="/modules/omise/img/bay.svg" class="bay">
@@ -42,7 +42,7 @@
                 </label>
               </li>
               <li class="item">
-                <input class="no-uniform" id="omise-internet-banking-bbl" name="offsite" type="radio" value="internet_banking_bbl" autocomplete="off">
+                <input id="omise-internet-banking-bbl" name="offsite" type="radio" value="internet_banking_bbl" autocomplete="off">
                 <label for="omise-internet-banking-bbl">
                   <div class="omise-logo-wrapper bbl">
                     <img src="/modules/omise/img/bbl.svg" class="bbl">


### PR DESCRIPTION
#### 1. Objective

Create Omise internet banking charge.

**Related information**:
- Related issue: #28 
- Related ticket: -

#### 2. Description of change

- Develop client-side script, JavaScript, to submit a selected bank in internet banking form to server side.

- Change a PrestaShop deprecated function, `Order.getOrderByCartId()`, to a function `Order. getIdByCartId()`.

- Change style of HTML ID of elements in internet banking payment.
Change from camel case to be separated with hyphen.

#### 3. Quality assurance

**Environments:**

- **Platform**: PrestaShop 1.7.2.3
- **Omise plugin**: Omise PrestaShop 1.2
- **PHP**: 5.6.31

**Details:**

There are 7 test cases below.

1. Successfully create Omise internet banking charge with Siam Commercial Bank (SCB)
2. Successfully create Omise internet banking charge with Krungthai Bank (KTB)
3. Successfully create Omise internet banking charge with Krungsri Bank (BAY)
4. Successfully create Omise internet banking charge with Bangkok Bank (BBL)
5. No any bank has been selected, display **custom** client-side script (jQuery Fancybox) warning message.
6. No any bank has been selected, display **native** client-side script warning message, if the jQuery Fancybox can not be loaded.
7. Failed create Omise internet banking payment charge.

Steps before test.

- Install and enable Omise payment module.
- At PrestaShop back office, Omise configuration page, enable internet banking payment.
- Go to PrestaShop front office, make sure current currency is applicable such as THB.
- Proceed checkout.
- At the payment step, select Internet Banking.

1. The screenshot below shows Omise dashboard, charge detail. This charge is internet banking charge with SCB.

![omise-dashboard-internet-banking-scb](https://user-images.githubusercontent.com/4145121/32275411-baba52e8-bf3d-11e7-9379-4603b8719a02.png)
 
2. The screenshot below shows Omise dashboard, charge detail. This charge is internet banking charge with KTB.

![omise-dashboard-internet-banking-ktb](https://user-images.githubusercontent.com/4145121/32275761-10b7122a-bf3f-11e7-95f4-107bb5454a1a.png)

3. The screenshot below shows Omise dashboard, charge detail. This charge is internet banking charge with BAY.

![omise-dashboard-internet-banking-bay](https://user-images.githubusercontent.com/4145121/32275769-16c57bde-bf3f-11e7-8b9f-56b8f191536e.png)

4. The screenshot below shows Omise dashboard, charge detail. This charge is internet banking charge with BBL.

![omise-dashboard-internet-banking-bbl](https://user-images.githubusercontent.com/4145121/32275824-3dd28654-bf3f-11e7-875f-7f2e88ed6b45.png)

5. The screenshot below shows PrestaShop 1.7 front office, Omise internet banking payment form. It shows **custom** client-side script (jQuery Fancybox) warning message, when internet banking payment form has no any selected bank.

![omise-prestashop-internet-banking-no-any-bank-selected-custom-messge-box](https://user-images.githubusercontent.com/4145121/32275857-5b1af71e-bf3f-11e7-8dcc-eecb2c9c43bb.png)

6. The screenshot below shows PrestaShop 1.7 front office, Omise internet banking payment form. It shows **native** client-side script warning message, when internet banking payment form has no any selected bank and the jQuery Fancybox can not be loaded.

<img width="1280" alt="omise-prestashop-internet-banking-no-any-bank-selected-native-messge-box" src="https://user-images.githubusercontent.com/4145121/32276034-2004b57e-bf40-11e7-95b1-4799befae33c.png">

7. The screenshot below shows PrestaShop 1.7 front office, failed Omise internet banking payment.

![omise-prestashop-failed-internet-banking-payment](https://user-images.githubusercontent.com/4145121/32276296-208b19b0-bf41-11e7-9bc3-08417ea8805f.png)

The screenshot below shows PrestaShop 1.7 back office, failed Omise internet banking payment. The order has been automatically canceled.

![prestashop-back-office-canceled-order-with-omise-internet-banking-payment](https://user-images.githubusercontent.com/4145121/32276306-30e0ce22-bf41-11e7-87cb-c92310f56c6d.png)

The screenshot below shows Omise dashboard failed internet banking charge.

![omise-dashboard-failed-internet-banking-charge](https://user-images.githubusercontent.com/4145121/32276322-4210a230-bf41-11e7-8e2f-c42557277e96.png)

#### 4. Impact of the change

`-`

#### 5. Priority of change

Normal

#### 6. Additional notes

Reference to the PrestaShop 1.7 deprecated function, [Order.getOrderByCartId()](https://github.com/PrestaShop/PrestaShop/blob/1.7.2.3/classes/order/Order.php#L1090).