### PR TITLE
Save payment method name correctly as selected by payer

### DIFF
--- a/omise/classes/payment_order.php
+++ b/omise/classes/payment_order.php
@@ -125,12 +125,8 @@ class PaymentOrder
      * @param int $id_order_state
      * @param string $id_charge The Omise charge ID.
      */
-    public function save($id_order_state = null, $id_charge = null)
+    public function save($id_order_state, $id_charge = null)
     {
-        if (empty($id_order_state)) {
-            $id_order_state = $this->getOrderStateAcceptedPayment();
-        }
-
         $this->module->validateOrder(
             $this->getCartId(),
             $id_order_state,

--- a/omise/classes/payment_order.php
+++ b/omise/classes/payment_order.php
@@ -122,18 +122,18 @@ class PaymentOrder
     /**
      * Save an order to database by using PrestaShop core function.
      *
-     * @param int $order_state
+     * @param int $id_order_state
      * @param string $id_charge The Omise charge ID.
      */
-    public function save($order_state = null, $id_charge = null)
+    public function save($id_order_state = null, $id_charge = null)
     {
-        if (empty($order_state)) {
-            $order_state = $this->getOrderStateAcceptedPayment();
+        if (empty($id_order_state)) {
+            $id_order_state = $this->getOrderStateAcceptedPayment();
         }
 
         $this->module->validateOrder(
             $this->getCartId(),
-            $order_state,
+            $id_order_state,
             $this->getCartOrderTotal(),
             $this->getModuleDisplayName(),
             $this->getOptionalMessage(),

--- a/omise/classes/payment_order.php
+++ b/omise/classes/payment_order.php
@@ -141,11 +141,6 @@ class PaymentOrder
         );
     }
 
-    public function saveAsProcessing()
-    {
-        $this->save($this->getOrderStateProcessingInProgress());
-    }
-
     /**
      * Update an order payment transaction ID to database.
      *

--- a/omise/classes/payment_order.php
+++ b/omise/classes/payment_order.php
@@ -123,15 +123,16 @@ class PaymentOrder
      * Save an order to database by using PrestaShop core function.
      *
      * @param int $id_order_state
+     * @param string $payment_method The name of payment method.
      * @param string $id_charge The Omise charge ID.
      */
-    public function save($id_order_state, $id_charge = null)
+    public function save($id_order_state, $payment_method, $id_charge = null)
     {
         $this->module->validateOrder(
             $this->getCartId(),
             $id_order_state,
             $this->getCartOrderTotal(),
-            $this->getModuleDisplayName(),
+            $payment_method,
             $this->getOptionalMessage(),
             $this->getExtraVariables($id_charge),
             $this->getCurrencyId(),

--- a/omise/controllers/front/internetbankingpayment.php
+++ b/omise/controllers/front/internetbankingpayment.php
@@ -14,7 +14,10 @@ class OmiseInternetBankingPaymentModuleFrontController extends OmiseBasePaymentM
     {
         $this->validateCart();
 
-        $this->payment_order->saveAsProcessing();
+        $this->payment_order->save(
+            $this->payment_order->getOrderStateProcessingInProgress(),
+            Omise::DEFAULT_INTERNET_BANKING_PAYMENT_TITLE
+        );
 
         try {
             $this->charge = $this->omise_charge->createInternetBanking(Tools::getValue('offsite'));

--- a/omise/controllers/front/payment.php
+++ b/omise/controllers/front/payment.php
@@ -19,7 +19,11 @@ class OmisePaymentModuleFrontController extends OmiseBasePaymentModuleFrontContr
             return;
         }
 
-        $this->payment_order->save(null, $this->charge->getId());
+        $this->payment_order->save(
+            $this->payment_order->getOrderStateAcceptedPayment(),
+            $this->setting->getTitle(),
+            $this->charge->getId()
+        );
 
         $this->setRedirectAfter('index.php?controller=order-confirmation' .
             '&id_cart=' . $this->context->cart->id .

--- a/omise/controllers/front/return.php
+++ b/omise/controllers/front/return.php
@@ -46,7 +46,7 @@ class OmiseReturnModuleFrontController extends OmiseBasePaymentModuleFrontContro
 
         $this->order_reference = $this->order->reference;
 
-        if ($this->order->payment != Omise::MODULE_DISPLAY_NAME) {
+        if ($this->order->module != Omise::MODULE_NAME) {
             $this->error_message = $this->l('Payment method is invalid.');
             return false;
         }

--- a/omise/controllers/front/threedomainsecurepayment.php
+++ b/omise/controllers/front/threedomainsecurepayment.php
@@ -13,7 +13,10 @@ class OmiseThreeDomainSecurePaymentModuleFrontController extends OmiseBasePaymen
     {
         $this->validateCart();
 
-        $this->payment_order->saveAsProcessing();
+        $this->payment_order->save(
+            $this->payment_order->getOrderStateProcessingInProgress(),
+            $this->setting->getTitle()
+        );
 
         parent::postProcess();
 

--- a/tests/autoload.php
+++ b/tests/autoload.php
@@ -4,3 +4,122 @@ require_once __DIR__ . '/../vendor/autoload.php';
 if (! defined('_PS_VERSION_')) {
     define('_PS_VERSION_', 'TEST_VERSION');
 }
+
+class UnitTestHelper extends PHPUnit_Framework_TestCase
+{
+    public function getMockedCharge()
+    {
+        $charge = $this->getMockBuilder(get_class(new stdClass()))
+            ->setMethods(
+                array(
+                    'getAuthorizeUri',
+                    'getErrorMessage',
+                    'getId',
+                    'isFailed',
+                )
+            )
+            ->getMock();
+
+        $charge->method('getId')->willReturn('omiseChargeId');
+
+        return $charge;
+    }
+
+    public function getMockedOmiseBasePaymentModuleFrontController()
+    {
+        $omise_base_payment_module_front_controller = $this->getMockBuilder(get_class(new stdClass()))
+            ->setMockClassName('OmiseBasePaymentModuleFrontController')
+            ->setMethods(
+                array(
+                    '__construct',
+                    'addOmiseTransaction',
+                    'l',
+                    'postProcess',
+                    'setRedirectAfter',
+                    'validateCart',
+                )
+            )
+            ->getMock();
+
+        return $omise_base_payment_module_front_controller;
+    }
+
+    public function getMockedPaymentModule()
+    {
+        $payment_module = $this->getMockBuilder(get_class(new stdClass()))
+            ->setMockClassName('PaymentModule')
+            ->setMethods(
+                array(
+                    '__construct',
+                    'display',
+                    'displayConfirmation',
+                    'install',
+                    'l',
+                    'registerHook',
+                    'uninstall',
+                    'unregisterHook',
+                )
+            )
+            ->getMock();
+
+        return $payment_module;
+    }
+
+    public function getMockedPaymentOrder()
+    {
+        $payment_order = $this->getMockBuilder(get_class(new stdClass()))
+            ->setMethods(
+                array(
+                    'getOrderStateAcceptedPayment',
+                    'getOrderStateProcessingInProgress',
+                    'save',
+                    'updatePaymentTransactionId',
+                    'updateStateToBeCanceled',
+                    'updateStateToBeSuccess',
+                )
+            )
+            ->getMock();
+
+        $payment_order->method('getOrderStateAcceptedPayment')->willReturn('orderStateAcceptedPayment');
+        $payment_order->method('getOrderStateProcessingInProgress')->willReturn('orderStatusProcessingInProgress');
+
+        return $payment_order;
+    }
+
+    public function getMockedSetting()
+    {
+        $setting = $this->getMockBuilder(get_class(new Setting()))
+            ->setMethods(
+                array(
+                    'delete',
+                    'getLivePublicKey',
+                    'getLiveSecretKey',
+                    'getPublicKey',
+                    'getSubmitAction',
+                    'getTestPublicKey',
+                    'getTestSecretKey',
+                    'getTitle',
+                    'isInternetBankingEnabled',
+                    'isModuleEnabled',
+                    'isSandboxEnabled',
+                    'isSubmit',
+                    'isThreeDomainSecureEnabled',
+                    'save',
+                    'saveTitle',
+                )
+            )
+            ->getMock();
+
+        $setting->method('getLivePublicKey')->willReturn('live_public_key');
+        $setting->method('getLiveSecretKey')->willReturn('live_secret_key');
+        $setting->method('getPublicKey')->willReturn('omise_public_key');
+        $setting->method('getSubmitAction')->willReturn('submit_action');
+        $setting->method('getTestPublicKey')->willReturn('test_public_key');
+        $setting->method('getTestSecretKey')->willReturn('test_secret_key');
+        $setting->method('getTitle')->willReturn('title');
+        $setting->method('isSandboxEnabled')->willReturn('sandbox_status');
+        $setting->method('isThreeDomainSecureEnabled')->willReturn('three_domain_secure_status');
+
+        return $setting;
+    }
+}

--- a/tests/unit/OmiseTest.php
+++ b/tests/unit/OmiseTest.php
@@ -11,21 +11,9 @@ class OmiseTest extends Mockery\Adapter\Phpunit\MockeryTestCase
 
     public function setup()
     {
-        $this->getMockBuilder(get_class(new stdClass()))
-            ->setMockClassName('PaymentModule')
-            ->setMethods(
-                array(
-                    '__construct',
-                    'display',
-                    'displayConfirmation',
-                    'install',
-                    'l',
-                    'registerHook',
-                    'uninstall',
-                    'unregisterHook',
-                )
-            )
-            ->getMock();
+        $unit_test_helper = new UnitTestHelper();
+
+        $unit_test_helper->getMockedPaymentModule();
 
         $this->checkout_form = $this->getMockBuilder(get_class(new CheckoutForm()))
             ->setMethods(
@@ -41,7 +29,7 @@ class OmiseTest extends Mockery\Adapter\Phpunit\MockeryTestCase
 
         $this->omise_transaction_model = $this->getMockedOmiseTransactionModel();
 
-        $this->setting = $this->getMockedSetting();
+        $this->setting = $unit_test_helper->getMockedSetting();
 
         $this->smarty = $this->getMockBuilder(get_class(new stdClass()))
             ->setMockClassName('Smarty')
@@ -56,9 +44,9 @@ class OmiseTest extends Mockery\Adapter\Phpunit\MockeryTestCase
         $this->omise->_path = '_path/';
         $this->omise->context = $this->getMockedContext();
         $this->omise->setCheckoutForm($this->checkout_form);
+        $this->omise->setOmiseTransactionModel($this->omise_transaction_model);
         $this->omise->setSetting($this->setting);
         $this->omise->setSmarty($this->smarty);
-        $this->omise->setOmiseTransactionModel($this->omise_transaction_model);
     }
 
     public function testConstructor_whenInitiateTheNewInstance_theDefaultValueOfTheAttributeSettingMustBeAvailable()
@@ -343,42 +331,5 @@ class OmiseTest extends Mockery\Adapter\Phpunit\MockeryTestCase
             ->getMock();
 
         return $omise_transaction_model;
-    }
-
-    private function getMockedSetting()
-    {
-        $setting = $this->getMockBuilder(get_class(new Setting()))
-            ->setMethods(
-                array(
-                    'delete',
-                    'getLivePublicKey',
-                    'getLiveSecretKey',
-                    'getPublicKey',
-                    'getSubmitAction',
-                    'getTestPublicKey',
-                    'getTestSecretKey',
-                    'getTitle',
-                    'isInternetBankingEnabled',
-                    'isModuleEnabled',
-                    'isSandboxEnabled',
-                    'isSubmit',
-                    'isThreeDomainSecureEnabled',
-                    'save',
-                    'saveTitle',
-                )
-            )
-            ->getMock();
-
-        $setting->method('getLivePublicKey')->willReturn('live_public_key');
-        $setting->method('getLiveSecretKey')->willReturn('live_secret_key');
-        $setting->method('getPublicKey')->willReturn('omise_public_key');
-        $setting->method('getSubmitAction')->willReturn('submit_action');
-        $setting->method('getTestPublicKey')->willReturn('test_public_key');
-        $setting->method('getTestSecretKey')->willReturn('test_secret_key');
-        $setting->method('getTitle')->willReturn('title');
-        $setting->method('isSandboxEnabled')->willReturn('sandbox_status');
-        $setting->method('isThreeDomainSecureEnabled')->willReturn('three_domain_secure_status');
-
-        return $setting;
     }
 }

--- a/tests/unit/classes/PaymentOrderTest.php
+++ b/tests/unit/classes/PaymentOrderTest.php
@@ -23,9 +23,9 @@ class PaymentOrderTest extends Mockery\Adapter\Phpunit\MockeryTestCase
 
     public function setup()
     {
-        $this->getMockBuilder(get_class(new stdClass()))
-            ->setMockClassName('PaymentModule')
-            ->getMock();
+        $unit_test_helper = new UnitTestHelper();
+
+        $unit_test_helper->getMockedPaymentModule();
 
         $cart = $this->getMockBuilder(get_class(new stdClass()))
             ->setMethods(
@@ -122,18 +122,19 @@ class PaymentOrderTest extends Mockery\Adapter\Phpunit\MockeryTestCase
 
         $this->module->expects($this->once())
             ->method('validateOrder')
-            ->with($this->cart_id,
+            ->with(
+                $this->cart_id,
                 'idOrderState',
                 $this->cart_order_total,
-                $this->module_display_name,
+                'paymentMethod',
                 $this->optional_message,
-                array(),
+                $this->extra_variables,
                 $this->currency_id,
                 $this->is_not_needed_rounding_card_order_total,
                 $this->customer_secure_key
             );
 
-        $this->payment_order->save('idOrderState', $id_charge);
+        $this->payment_order->save('idOrderState', 'paymentMethod', $id_charge);
     }
 
     public function testSave_theParameterOmiseChargeIdIsNull_noAnyOmiseChargeIdIsSaveToDatabaseForReference()
@@ -142,18 +143,19 @@ class PaymentOrderTest extends Mockery\Adapter\Phpunit\MockeryTestCase
 
         $this->module->expects($this->once())
             ->method('validateOrder')
-            ->with($this->cart_id,
+            ->with(
+                $this->cart_id,
                 'idOrderState',
                 $this->cart_order_total,
-                $this->module_display_name,
+                'paymentMethod',
                 $this->optional_message,
-                array(),
+                $this->extra_variables,
                 $this->currency_id,
                 $this->is_not_needed_rounding_card_order_total,
                 $this->customer_secure_key
             );
 
-        $this->payment_order->save('idOrderState', $id_charge);
+        $this->payment_order->save('idOrderState', 'paymentMethod', $id_charge);
     }
 
     public function testSave_theParameterOmiseChargeIdIsNotEmpty_saveAnOmiseChargeIdToDatabaseForReference()
@@ -162,10 +164,11 @@ class PaymentOrderTest extends Mockery\Adapter\Phpunit\MockeryTestCase
 
         $this->module->expects($this->once())
             ->method('validateOrder')
-            ->with($this->cart_id,
+            ->with(
+                $this->cart_id,
                 'idOrderState',
                 $this->cart_order_total,
-                $this->module_display_name,
+                'paymentMethod',
                 $this->optional_message,
                 array('transaction_id' => $id_charge),
                 $this->currency_id,
@@ -173,61 +176,7 @@ class PaymentOrderTest extends Mockery\Adapter\Phpunit\MockeryTestCase
                 $this->customer_secure_key
             );
 
-        $this->payment_order->save('idOrderState', $id_charge);
-    }
-
-    public function testSave_theParameterOrderStateIsEmpty_onlyOneOrderHasBeenSaved()
-    {
-        $this->module->expects($this->once())
-            ->method('validateOrder')
-            ->with($this->cart_id,
-                'idOrderState',
-                $this->cart_order_total,
-                $this->module_display_name,
-                $this->optional_message,
-                $this->extra_variables,
-                $this->currency_id,
-                $this->is_not_needed_rounding_card_order_total,
-                $this->customer_secure_key
-            );
-
-        $this->payment_order->save('idOrderState');
-    }
-
-    public function testSave_theParameterOrderStateIsNotEmpty_onlyOneOrderHasBeenSaved()
-    {
-        $this->module->expects($this->once())
-            ->method('validateOrder')
-            ->with($this->cart_id,
-                'orderState',
-                $this->cart_order_total,
-                $this->module_display_name,
-                $this->optional_message,
-                $this->extra_variables,
-                $this->currency_id,
-                $this->is_not_needed_rounding_card_order_total,
-                $this->customer_secure_key
-            );
-
-        $this->payment_order->save('orderState');
-    }
-
-    public function testSaveAsProcessing_saveTheOrder_saveAnOrderWithProcessingInProgressState()
-    {
-        $this->module->expects($this->once())
-            ->method('validateOrder')
-            ->with($this->cart_id,
-                $this->order_state_processing_in_progress,
-                $this->cart_order_total,
-                $this->module_display_name,
-                $this->optional_message,
-                $this->extra_variables,
-                $this->currency_id,
-                $this->is_not_needed_rounding_card_order_total,
-                $this->customer_secure_key
-            );
-
-        $this->payment_order->saveAsProcessing();
+        $this->payment_order->save('idOrderState', 'paymentMethod', $id_charge);
     }
 
     public function testUpdateStateToBeCanceled_currentOrderStateIsCanceled_orderStateMustNotBeUpdated()

--- a/tests/unit/classes/PaymentOrderTest.php
+++ b/tests/unit/classes/PaymentOrderTest.php
@@ -123,7 +123,7 @@ class PaymentOrderTest extends Mockery\Adapter\Phpunit\MockeryTestCase
         $this->module->expects($this->once())
             ->method('validateOrder')
             ->with($this->cart_id,
-                $this->order_state_accepted_payment,
+                'idOrderState',
                 $this->cart_order_total,
                 $this->module_display_name,
                 $this->optional_message,
@@ -133,7 +133,7 @@ class PaymentOrderTest extends Mockery\Adapter\Phpunit\MockeryTestCase
                 $this->customer_secure_key
             );
 
-        $this->payment_order->save(null, $id_charge);
+        $this->payment_order->save('idOrderState', $id_charge);
     }
 
     public function testSave_theParameterOmiseChargeIdIsNull_noAnyOmiseChargeIdIsSaveToDatabaseForReference()
@@ -143,7 +143,7 @@ class PaymentOrderTest extends Mockery\Adapter\Phpunit\MockeryTestCase
         $this->module->expects($this->once())
             ->method('validateOrder')
             ->with($this->cart_id,
-                $this->order_state_accepted_payment,
+                'idOrderState',
                 $this->cart_order_total,
                 $this->module_display_name,
                 $this->optional_message,
@@ -153,7 +153,7 @@ class PaymentOrderTest extends Mockery\Adapter\Phpunit\MockeryTestCase
                 $this->customer_secure_key
             );
 
-        $this->payment_order->save(null, $id_charge);
+        $this->payment_order->save('idOrderState', $id_charge);
     }
 
     public function testSave_theParameterOmiseChargeIdIsNotEmpty_saveAnOmiseChargeIdToDatabaseForReference()
@@ -163,7 +163,7 @@ class PaymentOrderTest extends Mockery\Adapter\Phpunit\MockeryTestCase
         $this->module->expects($this->once())
             ->method('validateOrder')
             ->with($this->cart_id,
-                $this->order_state_accepted_payment,
+                'idOrderState',
                 $this->cart_order_total,
                 $this->module_display_name,
                 $this->optional_message,
@@ -173,7 +173,7 @@ class PaymentOrderTest extends Mockery\Adapter\Phpunit\MockeryTestCase
                 $this->customer_secure_key
             );
 
-        $this->payment_order->save(null, $id_charge);
+        $this->payment_order->save('idOrderState', $id_charge);
     }
 
     public function testSave_theParameterOrderStateIsEmpty_onlyOneOrderHasBeenSaved()
@@ -181,7 +181,7 @@ class PaymentOrderTest extends Mockery\Adapter\Phpunit\MockeryTestCase
         $this->module->expects($this->once())
             ->method('validateOrder')
             ->with($this->cart_id,
-                $this->order_state_accepted_payment,
+                'idOrderState',
                 $this->cart_order_total,
                 $this->module_display_name,
                 $this->optional_message,
@@ -191,7 +191,7 @@ class PaymentOrderTest extends Mockery\Adapter\Phpunit\MockeryTestCase
                 $this->customer_secure_key
             );
 
-        $this->payment_order->save();
+        $this->payment_order->save('idOrderState');
     }
 
     public function testSave_theParameterOrderStateIsNotEmpty_onlyOneOrderHasBeenSaved()

--- a/tests/unit/controllers/front/OmiseBasePaymentModuleFrontControllerTest.php
+++ b/tests/unit/controllers/front/OmiseBasePaymentModuleFrontControllerTest.php
@@ -5,17 +5,12 @@ class OmiseBasePaymentModuleFrontControllerTest extends Mockery\Adapter\Phpunit\
 {
     public function setup()
     {
-        $this->getMockBuilder(get_class(new stdClass()))
-            ->setMockClassName('ModuleFrontController')
-            ->setMethods(
-                array(
-                    '__construct',
-                )
-            )
-            ->getMock();
+        $unit_test_helper = new UnitTestHelper();
+
+        $unit_test_helper->getMockedPaymentModule();
 
         $this->getMockBuilder(get_class(new stdClass()))
-            ->setMockClassName('PaymentModule')
+            ->setMockClassName('ModuleFrontController')
             ->setMethods(
                 array(
                     '__construct',

--- a/tests/unit/controllers/front/OmiseInternetBankingPaymentModuleFrontControllerTest.php
+++ b/tests/unit/controllers/front/OmiseInternetBankingPaymentModuleFrontControllerTest.php
@@ -10,19 +10,10 @@ class OmiseInternetBankingPaymentModuleFrontControllerTest extends Mockery\Adapt
 
     public function setup()
     {
-        $this->getMockBuilder(get_class(new stdClass()))
-            ->setMockClassName('OmiseBasePaymentModuleFrontController')
-            ->setMethods(
-                array(
-                    '__construct',
-                    'addOmiseTransaction',
-                    'l',
-                    'postProcess',
-                    'setRedirectAfter',
-                    'validateCart',
-                )
-            )
-            ->getMock();
+        $unit_test_helper = new UnitTestHelper();
+
+        $unit_test_helper->getMockedOmiseBasePaymentModuleFrontController();
+        $unit_test_helper->getMockedPaymentModule();
 
         m::mock('alias:\Order')
             ->shouldReceive('getIdByCartId')
@@ -33,9 +24,9 @@ class OmiseInternetBankingPaymentModuleFrontControllerTest extends Mockery\Adapt
             ->with('offsite')
             ->andReturn('mocked_offsite');
 
-        $this->charge = $this->getMockedCharge();
+        $this->charge = $unit_test_helper->getMockedCharge();
         $this->omise_charge = $this->getMockedOmiseCharge();
-        $this->payment_order = $this->getMockedPaymentOrder();
+        $this->payment_order = $unit_test_helper->getMockedPaymentOrder();
 
         $this->omise_internet_banking_payment_module_front_controller = new OmiseInternetBankingPaymentModuleFrontController();
         $this->omise_internet_banking_payment_module_front_controller->charge = $this->charge;
@@ -58,7 +49,7 @@ class OmiseInternetBankingPaymentModuleFrontControllerTest extends Mockery\Adapt
     {
         $this->payment_order
             ->expects($this->once())
-            ->method('saveAsProcessing');
+            ->method('save');
 
         $this->omise_internet_banking_payment_module_front_controller->postProcess();
     }
@@ -109,22 +100,6 @@ class OmiseInternetBankingPaymentModuleFrontControllerTest extends Mockery\Adapt
         $this->omise_internet_banking_payment_module_front_controller->postProcess();
     }
 
-    private function getMockedCharge()
-    {
-        $charge = $this->getMockBuilder(get_class(new stdClass()))
-            ->setMethods(
-                array(
-                    'getAuthorizeUri',
-                    'getErrorMessage',
-                    'getId',
-                    'isFailed',
-                )
-            )
-            ->getMock();
-
-        return $charge;
-    }
-
     private function getMockedContext()
     {
         $cart = $this->getMockBuilder(get_class(new stdClass()))->getMock();
@@ -149,19 +124,5 @@ class OmiseInternetBankingPaymentModuleFrontControllerTest extends Mockery\Adapt
         $omise_charge->method('createInternetBanking')->willReturn($this->charge);
 
         return $omise_charge;
-    }
-
-    private function getMockedPaymentOrder()
-    {
-        $payment_order = $this->getMockBuilder(get_class(new stdClass()))
-            ->setMethods(
-                array(
-                    'saveAsProcessing',
-                    'updatePaymentTransactionId',
-                )
-            )
-            ->getMock();
-
-        return $payment_order;
     }
 }

--- a/tests/unit/controllers/front/OmisePaymentModuleFrontControllerTest.php
+++ b/tests/unit/controllers/front/OmisePaymentModuleFrontControllerTest.php
@@ -6,32 +6,24 @@ class OmisePaymentModuleFrontControllerTest extends PHPUnit_Framework_TestCase
 
     public function setup()
     {
-        $this->getMockBuilder(get_class(new stdClass()))
-            ->setMockClassName('OmiseBasePaymentModuleFrontController')
-            ->setMethods(
-                array(
-                    '__construct',
-                    'addOmiseTransaction',
-                    'l',
-                    'postProcess',
-                    'setRedirectAfter',
-                    'validateCart',
-                )
-            )
-            ->getMock();
+        $unit_test_helper = new UnitTestHelper();
+
+        $unit_test_helper->getMockedOmiseBasePaymentModuleFrontController();
 
         $this->omise_payment_module_front_controller = new OmisePaymentModuleFrontController();
-        $this->omise_payment_module_front_controller->charge = $this->getMockedCharge();
+        $this->omise_payment_module_front_controller->charge = $unit_test_helper->getMockedCharge();
         $this->omise_payment_module_front_controller->context = $this->getMockedContext();
         $this->omise_payment_module_front_controller->module = $this->getMockedModule();
-        $this->omise_payment_module_front_controller->payment_order = $this->getMockedPaymentOrder();
+        $this->omise_payment_module_front_controller->payment_order = $unit_test_helper->getMockedPaymentOrder();
+        $this->omise_payment_module_front_controller->setting = $unit_test_helper->getMockedSetting();
     }
 
     public function testPostProcess_errorOccurred_noAnyOrderHasBeenSaved()
     {
         $this->omise_payment_module_front_controller->error_message = 'errorMessage';
 
-        $this->payment_order->expects($this->never())
+        $this->omise_payment_module_front_controller->payment_order
+            ->expects($this->never())
             ->method('save');
 
         $this->omise_payment_module_front_controller->postProcess();
@@ -39,25 +31,16 @@ class OmisePaymentModuleFrontControllerTest extends PHPUnit_Framework_TestCase
 
     public function testPostProcess_noErrorOccurred_saveTheOrder()
     {
-        $this->payment_order->expects($this->once())
+        $this->omise_payment_module_front_controller->payment_order
+            ->expects($this->once())
             ->method('save')
-            ->with(null, $this->omise_payment_module_front_controller->charge->getId());
+            ->with(
+                'orderStateAcceptedPayment',
+                'title',
+                'omiseChargeId'
+            );
 
         $this->omise_payment_module_front_controller->postProcess();
-    }
-
-    private function getMockedCharge()
-    {
-        $charge = $this->getMockBuilder(get_class(new stdClass()))
-            ->setMethods(
-                array(
-                    'getAuthorizeUri',
-                    'getId',
-                )
-            )
-            ->getMock();
-
-        return $charge;
     }
 
     private function getMockedContext()
@@ -82,18 +65,5 @@ class OmisePaymentModuleFrontControllerTest extends PHPUnit_Framework_TestCase
         $module->currentOrder = '3';
 
         return $module;
-    }
-
-    private function getMockedPaymentOrder()
-    {
-        $this->payment_order = $this->getMockBuilder(get_class(new stdClass()))
-            ->setMethods(
-                array(
-                    'save',
-                )
-            )
-            ->getMock();
-
-        return $this->payment_order;
     }
 }

--- a/tests/unit/controllers/front/OmiseReturnModuleFrontControllerTest.php
+++ b/tests/unit/controllers/front/OmiseReturnModuleFrontControllerTest.php
@@ -7,28 +7,22 @@ class OmiseReturnModuleFrontControllerTest extends Mockery\Adapter\Phpunit\Mocke
 
     public function setup()
     {
-        $this->getMockBuilder(get_class(new stdClass()))
-            ->setMockClassName('OmiseBasePaymentModuleFrontController')
-            ->setMethods(
-                array(
-                    '__construct',
-                    'addOmiseTransaction',
-                    'l',
-                    'postProcess',
-                    'setRedirectAfter',
-                    'validateCart',
-                )
-            )
-            ->getMock();
+        $unit_test_helper = new UnitTestHelper();
 
-        m::mock('overload:\Order');
+        $unit_test_helper->getMockedOmiseBasePaymentModuleFrontController();
 
-        m::mock('alias:\Tools')->shouldIgnoreMissing();
+        m::mock('alias:\Order');
+
+        m::mock('alias:\Tools')
+            ->shouldReceive('getValue')->with('id_cart')->andReturn('idCart')
+            ->shouldReceive('getValue')->with('id_module')->andReturn('idModule')
+            ->shouldReceive('getValue')->with('id_order')->andReturn('idOrder')
+            ->shouldReceive('getValue')->with('key')->andReturn('key');
 
         m::mock('alias:\Validate')->shouldIgnoreMissing();
 
         $this->omise_return_module_front_controller = new OmiseReturnModuleFrontController();
-        $this->omise_return_module_front_controller->payment_order = $this->getMockedPaymentOrder();
+        $this->omise_return_module_front_controller->payment_order = $unit_test_helper->getMockedPaymentOrder();
     }
 
     public function testPostProcess_orderIsNotFound_errorMessageMustBeDefined()
@@ -54,21 +48,5 @@ class OmiseReturnModuleFrontControllerTest extends Mockery\Adapter\Phpunit\Mocke
             ->shouldReceive('getValue')->with('key')->andReturn('key');
 
         $this->omise_return_module_front_controller->postProcess();
-    }
-
-    private function getMockedPaymentOrder()
-    {
-        $payment_order = $this->getMockBuilder(get_class(new stdClass()))
-            ->setMethods(
-                array(
-                    'saveAsProcessing',
-                    'updatePaymentTransactionId',
-                    'updateStateToBeCanceled',
-                    'updateStateToBeSuccess',
-                )
-            )
-            ->getMock();
-
-        return $payment_order;
     }
 }

--- a/tests/unit/controllers/front/OmiseThreeDomainSecurePaymentModuleFrontControllerTest.php
+++ b/tests/unit/controllers/front/OmiseThreeDomainSecurePaymentModuleFrontControllerTest.php
@@ -3,40 +3,31 @@ use \Mockery as m;
 
 class OmiseThreeDomainSecurePaymentModuleFrontControllerTest extends Mockery\Adapter\Phpunit\MockeryTestCase
 {
-    private $omise_base_payment_module_front_controller;
     private $omise_three_domain_secure_payment_module_front_controller;
 
     public function setup()
     {
-        $this->omise_base_payment_module_front_controller = $this->getMockBuilder(get_class(new stdClass()))
-            ->setMockClassName('OmiseBasePaymentModuleFrontController')
-            ->setMethods(
-                array(
-                    '__construct',
-                    'addOmiseTransaction',
-                    'l',
-                    'postProcess',
-                    'setRedirectAfter',
-                    'validateCart',
-                )
-            )
-            ->getMock();
+        $unit_test_helper = new UnitTestHelper();
+
+        $unit_test_helper->getMockedOmiseBasePaymentModuleFrontController();
 
         m::mock('alias:\Order')
             ->shouldReceive('getIdByCartId')
             ->andReturn('order');
 
         $this->omise_three_domain_secure_payment_module_front_controller = new OmiseThreeDomainSecurePaymentModuleFrontController();
-        $this->omise_three_domain_secure_payment_module_front_controller->charge = $this->getMockedCharge();
+        $this->omise_three_domain_secure_payment_module_front_controller->charge = $unit_test_helper->getMockedCharge();
         $this->omise_three_domain_secure_payment_module_front_controller->context = $this->getMockedContext();
-        $this->omise_three_domain_secure_payment_module_front_controller->payment_order = $this->getMockedPaymentOrder();
+        $this->omise_three_domain_secure_payment_module_front_controller->payment_order = $unit_test_helper->getMockedPaymentOrder();
+        $this->omise_three_domain_secure_payment_module_front_controller->setting = $unit_test_helper->getMockedSetting();
     }
 
     public function testPostProcess_createThreeDomainSecureCharge_saveAnOrderWithProcessingInProgressStatus()
     {
         $this->omise_three_domain_secure_payment_module_front_controller->payment_order
             ->expects($this->once())
-            ->method('saveAsProcessing');
+            ->method('save')
+            ->with('orderStatusProcessingInProgress', 'title');
 
         $this->omise_three_domain_secure_payment_module_front_controller->postProcess();
     }
@@ -85,20 +76,6 @@ class OmiseThreeDomainSecurePaymentModuleFrontControllerTest extends Mockery\Ada
         $this->omise_three_domain_secure_payment_module_front_controller->postProcess();
     }
 
-    private function getMockedCharge()
-    {
-        $charge = $this->getMockBuilder(get_class(new stdClass()))
-            ->setMethods(
-                array(
-                    'getAuthorizeUri',
-                    'getId',
-                )
-            )
-            ->getMock();
-
-        return $charge;
-    }
-
     private function getMockedContext()
     {
         $context = $this->getMockBuilder(get_class(new stdClass()))->getMock();
@@ -108,20 +85,5 @@ class OmiseThreeDomainSecurePaymentModuleFrontControllerTest extends Mockery\Ada
         $context->cart = $cart;
 
         return $context;
-    }
-
-    private function getMockedPaymentOrder()
-    {
-        $payment_order = $this->getMockBuilder(get_class(new stdClass()))
-            ->setMethods(
-                array(
-                    'saveAsProcessing',
-                    'updatePaymentTransactionId',
-                    'updateStateToBeCanceled',
-                )
-            )
-            ->getMock();
-
-        return $payment_order;
     }
 }


### PR DESCRIPTION
#### 1. Objective

Save payment method name correctly as selected by payer.

Currently, Omise PrestaShop has more than one payment method, card payment and internet banking payment. The payment method name that saved to the order should reflected the actual payment method that was chosen by the payer.

**Related information**:
- Related issue: -
- Related ticket: -

#### 2. Description of change

- Modify a function for save the order, `PaymentOrder.save()`. Make it requires one more parameter, payment method name.

- Modify all functions that saving the order. Make it send the required parameters.

- Unused and remove a function, `PaymentOrder.saveAsProcessing()`. To make the module has one function for save the order which is `PaymentOrder.save()`.

- Change the field used to check the condition of the module of saved order, when return from Omise API.

#### 3. Quality assurance

**Environments:**

- **Platform**: PrestaShop 1.7.2.4
- **Omise plugin**: Omise PrestaShop 1.3
- **PHP**: 5.6.31

**Details:**

Before change

The payment method name that saved to the order has been fixed by using name, Omise (`Omise::MODULE_DISPLAY_NAME`).

The screenshot below shows PrestaShop back office, order detail page. In the red box, the payment method of this order is fixed, Omise.

![prestashop-1 7 2 4-fixed-payment-method-name](https://user-images.githubusercontent.com/4145121/32523613-a14e3bba-c44e-11e7-9c58-edad2af4cfb8.png)

After change

The payment method that saved to the order is the actual payment method that selected by payer.

The screenshot below shows PrestaShop front office, completed card payment page. In the red box, the payment method name of card payment is the setting of title.

![prestashop-1 7 2 4-successful-omise-card-payment](https://user-images.githubusercontent.com/4145121/32524113-d43b3710-c450-11e7-8161-af248d05ca7a.png)

The screenshot below shows PrestaShop back office, order detail page. In the red box, the payment method name of card payment is the setting of title.

![prestashop-1 7 2 4-back-office-order-detail-page-payment-method-is-setting-of-title](https://user-images.githubusercontent.com/4145121/32524322-be40f804-c451-11e7-8272-5162c83c63c5.png)

The screenshot below shows PrestaShop front office, completed internet banking payment page. In the red box, the payment method name is Internet Banking.

![prestashop-1 7 2 4-successful-omise-internet-banking-payment](https://user-images.githubusercontent.com/4145121/32524339-d865fd42-c451-11e7-8ac8-ff507177e219.png)

The screenshot below shows PrestaShop back office, order detail page. In the red box, the payment method name of internet banking payment is Internet Banking.

![prestashop-1 7 2 4-back-office-order-detail-page-internet-banking-payment-method](https://user-images.githubusercontent.com/4145121/32524530-d9e3acfe-c452-11e7-910a-a6dd46cad9ca.png)

#### 4. Impact of the change

`-`

#### 5. Priority of change

Normal

#### 6. Additional notes

For the payment method name saved to the order, card payment is the setting of title. Internet banking payment is fixed the name Internet Banking.