### PR TITLE
Attach PrestaShop order ID to metadata of Omise charge

### DIFF
--- a/omise/classes/omise_charge_class.php
+++ b/omise/classes/omise_charge_class.php
@@ -118,6 +118,14 @@ class OmiseChargeClass
     }
 
     /**
+     * @return array
+     */
+    protected function getMetadata()
+    {
+        return array('order_id' => Order::getIdByCartId($this->context->cart->id));
+    }
+
+    /**
      * Generate a PrestaShop site URL that is used to receive the redirect back from Omise API.
      *
      * @return string

--- a/omise/classes/omise_charge_class.php
+++ b/omise/classes/omise_charge_class.php
@@ -56,6 +56,7 @@ class OmiseChargeClass
             'amount' => $this->getAmount(),
             'currency' => $this->getCurrencyCode(),
             'description' => $this->getChargeDescription(),
+            'metadata' => $this->getMetadata(),
             'offsite' => $offsite,
             'return_uri' => $this->getReturnUri(),
         );

--- a/omise/classes/omise_charge_class.php
+++ b/omise/classes/omise_charge_class.php
@@ -34,6 +34,7 @@ class OmiseChargeClass
             'capture' => 'true',
             'currency' => $this->getCurrencyCode(),
             'description' => $this->getChargeDescription(),
+            'metadata' => $this->getMetadata(),
         );
 
         if ($this->setting->isThreeDomainSecureEnabled()) {

--- a/omise/controllers/front/payment.php
+++ b/omise/controllers/front/payment.php
@@ -13,17 +13,25 @@ class OmisePaymentModuleFrontController extends OmiseBasePaymentModuleFrontContr
     {
         $this->validateCart();
 
+        $this->payment_order->save(
+            $this->payment_order->getOrderStateProcessingInProgress(),
+            $this->setting->getTitle()
+        );
+
         parent::postProcess();
 
+        $id_order = Order::getIdByCartId($this->context->cart->id);
+
+        if (! empty($this->charge)) {
+            $this->payment_order->updatePaymentTransactionId($id_order, $this->charge->getId());
+        }
+
         if (! empty($this->error_message)) {
+            $this->payment_order->updateStateToBeCanceled(new Order($id_order));
             return;
         }
 
-        $this->payment_order->save(
-            $this->payment_order->getOrderStateAcceptedPayment(),
-            $this->setting->getTitle(),
-            $this->charge->getId()
-        );
+        $this->payment_order->updateStateToBeSuccess(new Order($id_order));
 
         $this->setRedirectAfter('index.php?controller=order-confirmation' .
             '&id_cart=' . $this->context->cart->id .

--- a/tests/unit/classes/OmiseChargeClassTest.php
+++ b/tests/unit/classes/OmiseChargeClassTest.php
@@ -189,6 +189,7 @@ class OmiseChargeClassTest extends Mockery\Adapter\Phpunit\MockeryTestCase
             'capture' => 'true',
             'currency' => 'THB',
             'description' => 'Charge a card using a token from PrestaShop (' . _PS_VERSION_ . ')',
+            'metadata' => array('order_id' => 1234),
         );
 
         return $charge_request;

--- a/tests/unit/classes/OmiseChargeClassTest.php
+++ b/tests/unit/classes/OmiseChargeClassTest.php
@@ -208,6 +208,7 @@ class OmiseChargeClassTest extends Mockery\Adapter\Phpunit\MockeryTestCase
         $charge_request = array(
             'amount' => 10025,
             'currency' => 'THB',
+            'metadata' => array('order_id' => 1234),
             'offsite' => 'offsite',
             'description' => 'Charge a card using a token from PrestaShop (' . _PS_VERSION_ . ')',
             'return_uri' => 'returnUri?id_cart=1&id_module=omise&id_order=1234&key=customerSecureKey',

--- a/tests/unit/controllers/front/OmisePaymentModuleFrontControllerTest.php
+++ b/tests/unit/controllers/front/OmisePaymentModuleFrontControllerTest.php
@@ -1,6 +1,9 @@
 <?php
-class OmisePaymentModuleFrontControllerTest extends PHPUnit_Framework_TestCase
+use \Mockery as m;
+
+class OmisePaymentModuleFrontControllerTest extends Mockery\Adapter\Phpunit\MockeryTestCase
 {
+    private $omise_base_payment_module_front_controller;
     private $omise_payment_module_front_controller;
     private $payment_order;
 
@@ -8,7 +11,11 @@ class OmisePaymentModuleFrontControllerTest extends PHPUnit_Framework_TestCase
     {
         $unit_test_helper = new UnitTestHelper();
 
-        $unit_test_helper->getMockedOmiseBasePaymentModuleFrontController();
+        $this->omise_base_payment_module_front_controller = $unit_test_helper->getMockedOmiseBasePaymentModuleFrontController();
+
+        m::mock('alias:\Order')
+            ->shouldReceive('getIdByCartId')
+            ->andReturn('id_order');
 
         $this->omise_payment_module_front_controller = new OmisePaymentModuleFrontController();
         $this->omise_payment_module_front_controller->charge = $unit_test_helper->getMockedCharge();
@@ -18,27 +25,50 @@ class OmisePaymentModuleFrontControllerTest extends PHPUnit_Framework_TestCase
         $this->omise_payment_module_front_controller->setting = $unit_test_helper->getMockedSetting();
     }
 
-    public function testPostProcess_errorOccurred_noAnyOrderHasBeenSaved()
-    {
-        $this->omise_payment_module_front_controller->error_message = 'errorMessage';
-
-        $this->omise_payment_module_front_controller->payment_order
-            ->expects($this->never())
-            ->method('save');
-
-        $this->omise_payment_module_front_controller->postProcess();
-    }
-
-    public function testPostProcess_noErrorOccurred_saveTheOrder()
+    public function testPostProcess_createCharge_saveAnOrderWithTheOrderStatusIsProcessing()
     {
         $this->omise_payment_module_front_controller->payment_order
             ->expects($this->once())
             ->method('save')
             ->with(
-                'orderStateAcceptedPayment',
-                'title',
+                'orderStatusProcessingInProgress',
+                'title'
+            );
+
+        $this->omise_payment_module_front_controller->postProcess();
+    }
+
+    public function testPostProcess_chargeResultIsNotEmpty_saveOmiseChargeIdToPrestaShopOrder()
+    {
+        $this->omise_payment_module_front_controller->payment_order
+            ->expects($this->once())
+            ->method('updatePaymentTransactionId')
+            ->with(
+                'id_order',
                 'omiseChargeId'
             );
+
+        $this->omise_payment_module_front_controller->postProcess();
+    }
+
+    public function testPostProcess_createChargeIsError_updateOrderStatusToBeCanceled()
+    {
+        $this->omise_payment_module_front_controller->error_message = 'errorMessage';
+
+        $this->omise_payment_module_front_controller->payment_order
+            ->expects($this->once())
+            ->method('updateStateToBeCanceled');
+
+        $this->omise_payment_module_front_controller->postProcess();
+    }
+
+    public function testPostProcess_createChargeIsSuccess_redirectToOrderConfirmationPage()
+    {
+        $this->omise_payment_module_front_controller->error_message = '';
+
+        $this->omise_payment_module_front_controller->payment_order
+            ->expects($this->once())
+            ->method('updateStateToBeSuccess');
 
         $this->omise_payment_module_front_controller->postProcess();
     }

--- a/tests/unit/controllers/front/OmisePaymentModuleFrontControllerTest.php
+++ b/tests/unit/controllers/front/OmisePaymentModuleFrontControllerTest.php
@@ -3,7 +3,6 @@ use \Mockery as m;
 
 class OmisePaymentModuleFrontControllerTest extends Mockery\Adapter\Phpunit\MockeryTestCase
 {
-    private $omise_base_payment_module_front_controller;
     private $omise_payment_module_front_controller;
     private $payment_order;
 
@@ -11,7 +10,7 @@ class OmisePaymentModuleFrontControllerTest extends Mockery\Adapter\Phpunit\Mock
     {
         $unit_test_helper = new UnitTestHelper();
 
-        $this->omise_base_payment_module_front_controller = $unit_test_helper->getMockedOmiseBasePaymentModuleFrontController();
+        $unit_test_helper->getMockedOmiseBasePaymentModuleFrontController();
 
         m::mock('alias:\Order')
             ->shouldReceive('getIdByCartId')

--- a/tests/unit/controllers/front/OmisePaymentModuleFrontControllerTest.php
+++ b/tests/unit/controllers/front/OmisePaymentModuleFrontControllerTest.php
@@ -61,7 +61,7 @@ class OmisePaymentModuleFrontControllerTest extends Mockery\Adapter\Phpunit\Mock
         $this->omise_payment_module_front_controller->postProcess();
     }
 
-    public function testPostProcess_createChargeIsSuccess_redirectToOrderConfirmationPage()
+    public function testPostProcess_createChargeIsSuccess_updateOrderStatusToBeSuccess()
     {
         $this->omise_payment_module_front_controller->error_message = '';
 


### PR DESCRIPTION
#### 1. Objective

Make it easier to refer to the order of PrestaShop from Omise dashboard by attach PrestaShop order ID to metadata of Omise charge.

**Related information**:
- Related issue: -
- Related ticket: -

#### 2. Description of change

- Add a function to generate Omise metadata for charge.
- Attach metadata that contained PrestaShop order ID to the Omise charge both card payment and internet banking payment.

#### 3. Quality assurance

**Environments:**

- **Platform**: PrestaShop 1.7.2.4
- **Omise plugin**: Omise PrestaShop 1.3
- **PHP**: 5.6.31

**Details:**

There are 6 test cases.

1. Success normal card payment.
2. Failed normal card payment.
3. Success 3-D Secure payment.
4. Failed 3-D Secure payment.
5. Success internet banking payment.
6. Failed internet banking payment.

All test case expect metadata saved and displayed in Omise dashboard.

1. Success normal card payment.

The screenshot below shows success charge detail in Omise dashboard. In the red box, order ID of PrestaShop has been saved and displayed as metadata of Omise charge.

![omise-dashboard-prestashop-1 7 2 4-charge-detail-metadata-of-card-payment](https://user-images.githubusercontent.com/4145121/32715053-1d294e18-c883-11e7-9dc8-45011e3002b1.png)

The screenshot below shows order detail in PrestaShop back office. In the red box, the step of order status has been changed from 1 step to 2 steps, save order as processing and update order status to be success (Payment accepted).

![prestashop-order-detail-normal-card-payment-2-steps-of-order-statuses](https://user-images.githubusercontent.com/4145121/32715130-829b6a10-c883-11e7-833d-c9e8d4ffb828.png)

2. Failed normal card payment.

The screenshot below shows failed charge detail in Omise dashboard. In the red box, order ID of PrestaShop has been saved and displayed as metadata of Omise charge.

![omise-dashboard-prestashop-1 7 2 4-charge-detail-metadata-of-failed-card-payment](https://user-images.githubusercontent.com/4145121/32715318-661ee046-c884-11e7-867e-59b322fab319.png)

The screenshot below shows failed order detail in PrestaShop back office. In the red box, the step of order status has been changed to 2 steps same as the first test case.

![prestashop-order-detail-failed-normal-card-payment-2-steps-of-order-statuses](https://user-images.githubusercontent.com/4145121/32715295-46fc68be-c884-11e7-9de4-e0e14d1a2fc3.png)

3. Success 3-D Secure payment.

The screenshot below shows success 3-D Secure charge detail in Omise dashboard. In the red box, order ID of PrestaShop has been saved and displayed as metadata of Omise charge.

![omise-dashboard-prestashop-1 7 2 4-charge-detail-metadata-of-3ds-card-payment](https://user-images.githubusercontent.com/4145121/32715486-257325ba-c885-11e7-9ce8-a7553982b1c5.png)

4. Failed 3-D Secure payment.

The screenshot below shows failed 3-D Secure charge detail in Omise dashboard. In the red box, order ID of PrestaShop has been saved and displayed as metadata of Omise charge.

![omise-dashboard-prestashop-1 7 2 4-charge-detail-metadata-of-failed-3ds-card-payment](https://user-images.githubusercontent.com/4145121/32715555-662517a8-c885-11e7-972a-c56755a2855a.png)

5. Success internet banking payment.

The screenshot below shows success internet banking charge detail in Omise dashboard. In the red box, order ID of PrestaShop has been saved and displayed as metadata of Omise charge.

![omise-dashboard-prestashop-1 7 2 4-charge-detail-metadata-of-internet-banking-payment](https://user-images.githubusercontent.com/4145121/32715670-d95697e2-c885-11e7-8add-f9527af3e554.png)

6. Failed internet banking payment.

The screenshot below shows failed internet banking charge detail in Omise dashboard. In the red box, order ID of PrestaShop has been saved and displayed as metadata of Omise charge.

![omise-dashboard-prestashop-1 7 2 4-charge-detail-metadata-of-failed-internet-banking-payment](https://user-images.githubusercontent.com/4145121/32715679-e2b81194-c885-11e7-97b2-10e6fdb1deec.png)

#### 4. Impact of the change

For the normal card payment, the step of payment processing has been changed. It has been changed,

From 1 step of saving an PrestaShop order when Omise charged is success

To 2 steps of saving an PrestaShop order by
- Save PrestaShop order as processing to use the generated order ID attached it to Omise charge metadata
- Update PrestaShop order status to be success, if Omise charge is success or update PrestaShop order status to be canceled, if Omise charge is failed.

So, the record of order status has 2 records as mentioned from the above first and second test cases.

#### 5. Priority of change

Normal

#### 6. Additional notes

`-`