### PR TITLE
Display webhooks endpoint in setting page

### DIFF
--- a/omise/omise.php
+++ b/omise/omise.php
@@ -210,9 +210,25 @@ class Omise extends PaymentModule
             'test_secret_key' => $this->setting->getTestSecretKey(),
             'title' => $this->setting->getTitle(),
             'three_domain_secure_status' => $this->setting->isThreeDomainSecureEnabled(),
+            'webhooks_endpoint' => $this->getWebhooksEndpoint(),
         ));
 
         return $this->display(__FILE__, 'views/templates/admin/setting.tpl');
+    }
+
+    /**
+     * Generate the URL to receive the requests from Omise server when events are triggered.
+     *
+     * The examples of events such as charge has been created, updated or charge is completed.
+     *
+     * @return string Return the URL that link to front module controller.
+     *
+     * @see LinkCore::getModuleLink() The PrestaShop function used to generate link.
+     * @see OmiseWebhooksModuleFrontController The Omise controller used to handle requests from Omise server.
+     */
+    protected function getWebhooksEndpoint()
+    {
+        return $this->context->link->getModuleLink(Omise::MODULE_NAME, 'webhooks', [], true);
     }
 
     public function hookDisplayOrderConfirmation($params)

--- a/omise/views/templates/admin/setting.tpl
+++ b/omise/views/templates/admin/setting.tpl
@@ -59,6 +59,14 @@
         </div>
       </div>
       <div class="form-group">
+        <label class="control-label col-lg-3" for="webhooks_endpoint">{l s='Webhooks endpoint' mode='omise'}</label>
+        <div class="col-lg-9">
+          <p class="form-control-static">
+            <code>{$webhooks_endpoint}</code>
+          </p>
+        </div>
+      </div>
+      <div class="form-group">
         <label class="control-label col-lg-3"><b>{l s='Advance Settings' mode='omise'}</b></label>
       </div>
       <div class="form-group">

--- a/tests/unit/OmiseTest.php
+++ b/tests/unit/OmiseTest.php
@@ -80,6 +80,7 @@ class OmiseTest extends Mockery\Adapter\Phpunit\MockeryTestCase
 
     public function testGetContent_merchantOpenTheSettingPage_retrieveSettingDataFromTheDatabaseAndDisplayOnThePage()
     {
+        $this->omise->context->link->method('getModuleLink')->willReturn('webhooks_endpoint');
         $this->setting->method('isInternetBankingEnabled')->willReturn('internet_banking_status');
         $this->setting->method('isModuleEnabled')->willReturn('module_status');
 
@@ -96,6 +97,7 @@ class OmiseTest extends Mockery\Adapter\Phpunit\MockeryTestCase
                 'test_secret_key' => 'test_secret_key',
                 'title' => 'title',
                 'three_domain_secure_status' => 'three_domain_secure_status',
+                'webhooks_endpoint' => 'webhooks_endpoint',
             ));
 
         $this->omise->getContent();


### PR DESCRIPTION
#### 1. Objective

Makes the merchant knows the webhooks endpoint to configure in the Omise dashboard by display the webhooks endpoint in the PrestaShop back office, Omise setting page.

**Related information**:
- Related issue: -
- Related ticket: -

#### 2. Description of change

- Add a function to generate webhooks endpoint.
- Display webhook endpoint at the setting page.

#### 3. Quality assurance

**Environments:**

- **Platform**: PrestaShop 1.7.2.4
- **Omise plugin**: Omise PrestaShop 1.3
- **PHP**: 5.6.31

**Details:**

The screenshot below shows PrestaShop back office, Omise setting page. In the red box, it shows webhooks endpoint that has been added by this pull request.

![prestashop-1 7 2 4-back-office-webhooks-endpoint-in-omise-setting-page](https://user-images.githubusercontent.com/4145121/32900871-107a37fe-cb21-11e7-895e-9f270a492081.png)

#### 4. Impact of the change

`-`

#### 5. Priority of change

Normal

#### 6. Additional notes

To configure webhooks endpoint in the Omise dashboard, it can be done by log in to Omise dashboard, from the left side menu click Webhooks.

The screenshot below shows Omise dashboard. In the red box, it shows Webhooks menu.

![omise-dashboard-webhooks-menu](https://user-images.githubusercontent.com/4145121/32901786-3e6fe38c-cb23-11e7-801f-d7ac0f1cedad.png)

The screenshot below shows Omise dashboard, Webhooks configuration page. To configure webhooks endpoint, click Edit.

![omise-dashboard-webhooks-page](https://user-images.githubusercontent.com/4145121/32901920-ab8365d4-cb23-11e7-8aef-a6e9a6fb4027.png)

Enter the webhooks endpoint by using the webhooks that generated and displayed in the PrestaShop back office, Omise setting page.

**Please note that the webhooks endpoint must be valid and available in HTTPS for the security reason. The screenshot below shows the example webhooks endpoint.**

![omise-dashboard-configure-webhooks](https://user-images.githubusercontent.com/4145121/32902964-619c3dda-cb26-11e7-8c26-0fb0e197504b.png)

After successfully updated, when the [events](https://www.omise.co/api-webhooks#list-of-all-possible-events) has been triggered, the request from Omise server will be sent to the URL that has been configured in the webhooks endpoint.