### PR TITLE
Add an empty front office controller for webhooks

### DIFF
--- a/omise/controllers/front/webhooks.php
+++ b/omise/controllers/front/webhooks.php
@@ -1,0 +1,12 @@
+<?php
+if (! defined('_PS_VERSION_')) {
+    exit();
+}
+
+class OmiseWebhooksModuleFrontController extends ModuleFrontController
+{
+    public function postProcess()
+    {
+        $this->setTemplate('module:omise/views/templates/front/webhooks.tpl');
+    }
+}

--- a/tests/unit/controllers/front/OmiseWebhooksModuleFrontControllerTest.php
+++ b/tests/unit/controllers/front/OmiseWebhooksModuleFrontControllerTest.php
@@ -1,0 +1,29 @@
+<?php
+class OmiseWebhooksModuleFrontControllerTest extends PHPUnit_Framework_TestCase
+{
+    private $omise_webhooks_module_front_controller;
+
+    public function setup()
+    {
+        $this->getMockBuilder(get_class(new stdClass()))
+            ->setMockClassName('ModuleFrontController')
+            ->setMethods(
+                array(
+                    'setTemplate',
+                )
+            )
+            ->getMock();
+
+        $this->omise_webhooks_module_front_controller = new OmiseWebhooksModuleFrontController();
+    }
+
+    public function testPostProcess_postProcess_displayOmiseWebhooksPage()
+    {
+        $this->omise_webhooks_module_front_controller
+            ->expects($this->once())
+            ->method('setTemplate')
+            ->with('module:omise/views/templates/front/webhooks.tpl');
+
+        $this->omise_webhooks_module_front_controller->postProcess();
+    }
+}


### PR DESCRIPTION
#### 1. Objective

To make sure that the generated webhooks endpoint from the previous pull request, #43, and the front office controller are worked. The endpoint URL is available and it can be accessed.

The front office controller in this pull request will be used to handle the webhooks request from Omise server.

**Related information**:
- Related issue: -
- Related ticket: -

#### 2. Description of change

- Add a front module controller.
- Add an empty template.

#### 3. Quality assurance

**Environments:**

- **Platform**: PrestaShop 1.7.2.4
- **Omise plugin**: Omise PrestaShop 1.3
- **PHP**: 5.6.31

**Details:**

Open the generated webhooks endpoint URL that displayed in the PrestaShop back office, Omise setting page.

![prestashop-back-office-1 7 2 4-omise-setting-page-webhooks-endpoint](https://user-images.githubusercontent.com/4145121/32929459-bd057812-cb8a-11e7-8383-7f65b01f583a.png)

The screenshot below shows the empty page from the webhooks endpoint URL. The URL can be accessed via HTTP GET.

<img width="1280" alt="omise-prestashop-webhooks-http-get-is-available" src="https://user-images.githubusercontent.com/4145121/32929569-7b327a42-cb8b-11e7-9aaa-3377673d7d2f.png">

The screenshot below shows the webhooks endpoint URL can be accessed via HTTP POST.

<img width="1280" alt="omise-prestashop-webhooks-http-post-is-available" src="https://user-images.githubusercontent.com/4145121/32929576-870e3392-cb8b-11e7-8e22-bf0d6bbd9c4c.png">

#### 4. Impact of the change

`-`

#### 5. Priority of change

Normal

#### 6. Additional notes

`-`