### PR TITLE
Handle an Omise event, charge.complete

### DIFF
--- a/omise/classes/omise_charge_class.php
+++ b/omise/classes/omise_charge_class.php
@@ -11,6 +11,9 @@ if (defined('_PS_MODULE_DIR_')) {
 
 class OmiseChargeClass
 {
+    const STATUS_FAILED = 'failed';
+    const STATUS_SUCCESSFUL = 'successful';
+
     protected $context;
     protected $charge_response;
     protected $setting;

--- a/omise/classes/omise_logger.php
+++ b/omise/classes/omise_logger.php
@@ -1,0 +1,40 @@
+<?php
+if (! defined('_PS_VERSION_')) {
+    exit();
+}
+
+class OmiseLogger
+{
+    const ERROR = 3;
+    const INFO = 1;
+    const MAJOR_ISSUE = 4;
+    const WARNING = 2;
+
+    /**
+     * Add log message to PrestaShop database.
+     * The added log message will be displayed in PrestaShop back office.
+     *
+     * @param string $message
+     * @param int $severity
+     *
+     * @return bool
+     *
+     * @see PrestaShopLoggerCore::addLog()
+     */
+    public function add($message, $severity = OmiseLogger::INFO)
+    {
+        $allow_duplicate = true;
+        $error_code = null;
+        $object_id = null;
+        $object_type = null;
+
+        return Logger::addLog(
+            $message,
+            $severity,
+            $error_code,
+            $object_type,
+            $object_id,
+            $allow_duplicate
+        );
+    }
+}

--- a/omise/classes/omise_transaction_model.php
+++ b/omise/classes/omise_transaction_model.php
@@ -67,4 +67,30 @@ class OmiseTransactionModel extends ObjectModel
 
         return $result['id_charge'];
     }
+
+    /**
+     * Return a PrestaShop order ID by searching from a given parameter, Omise charge ID.
+     *
+     * @param string $id_charge An Omise charge ID.
+     *
+     * @return int|false A PrestaShop order ID or false, if a PrestaShop order ID is not found.
+     */
+    public function getIdOrder($id_charge)
+    {
+        $query = new DbQuery();
+        $query->select('id_order');
+        $query->from('omise_transaction');
+        $query->where('id_charge = \'' . pSQL($id_charge) . '\'');
+
+        $result = Db::getInstance()->getRow($query);
+
+        if (! $result
+            || empty($result)
+            || ! array_key_exists('id_order', $result)
+        ) {
+            return false;
+        }
+
+        return $result['id_order'];
+    }
 }

--- a/omise/classes/omise_webhooks.php
+++ b/omise/classes/omise_webhooks.php
@@ -1,0 +1,32 @@
+<?php
+if (! defined('_PS_VERSION_')) {
+    exit();
+}
+
+class OmiseWebhooks
+{
+    /**
+     * Return the request body that received from Omise server.
+     *
+     * @return mixed|null The null will be returned. For examples,
+     *
+     * - The request from Omise server is HTTP GET not HTTP POST.
+     * - The request body is empty.
+     * - The request body is invalid JSON format.
+     */
+    public function getRequestBody()
+    {
+        $return_value_as_array = true;
+
+        $data = file_get_contents('php://input');
+
+        return json_decode($data, $return_value_as_array);
+    }
+
+    public function sendRawHeaderAsBadRequest()
+    {
+        $replace_previous_similar_header = true;
+
+        header('HTTP/1.1 400 Bad Request', $replace_previous_similar_header, 400);
+    }
+}

--- a/omise/controllers/front/webhooks.php
+++ b/omise/controllers/front/webhooks.php
@@ -3,10 +3,80 @@ if (! defined('_PS_VERSION_')) {
     exit();
 }
 
+if (defined('_PS_MODULE_DIR_')) {
+    require_once _PS_MODULE_DIR_ . 'omise/classes/omise_webhooks.php';
+    require_once _PS_MODULE_DIR_ . 'omise/events/omise_event_handler.php';
+}
+
 class OmiseWebhooksModuleFrontController extends ModuleFrontController
 {
+    /**
+     * @var OmiseEventHandler
+     */
+    protected $omise_event_handler;
+
+    /**
+     * @var OmiseWebhooks
+     */
+    protected $omise_webhooks;
+
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->setOmiseEventHandler(new OmiseEventHandler());
+        $this->setOmiseWebhooks(new OmiseWebhooks());
+    }
+
+    /**
+     * @param mixed $request_body The array of JSON decoded from Omise event object.
+     *
+     * @return bool
+     */
+    protected function isRequestValid($request_body)
+    {
+        if (is_null($request_body)) {
+            return false;
+        }
+
+        if (! array_key_exists('object', $request_body)) {
+            return false;
+        }
+
+        if ($request_body['object'] !== 'event') {
+            return false;
+        }
+
+        return true;
+    }
+
     public function postProcess()
     {
         $this->setTemplate('module:omise/views/templates/front/webhooks.tpl');
+
+        $request_body = $this->omise_webhooks->getRequestBody();
+
+        if (! $this->isRequestValid($request_body)) {
+            $this->omise_webhooks->sendRawHeaderAsBadRequest();
+            return;
+        }
+
+        $this->omise_event_handler->handle($request_body);
+    }
+
+    /**
+     * @param OmiseEventHandler $omise_event_handler The instance of class, OmiseEventHandler.
+     */
+    public function setOmiseEventHandler($omise_event_handler)
+    {
+        $this->omise_event_handler = $omise_event_handler;
+    }
+
+    /**
+     * @param OmiseWebhooks $omise_webhooks The instance of class, OmiseWebhooks.
+     */
+    public function setOmiseWebhooks($omise_webhooks)
+    {
+        $this->omise_webhooks = $omise_webhooks;
     }
 }

--- a/omise/events/omise_base_event.php
+++ b/omise/events/omise_base_event.php
@@ -1,0 +1,25 @@
+<?php
+if (! defined('_PS_VERSION_')) {
+    exit();
+}
+
+if (defined('_PS_MODULE_DIR_')) {
+    require_once _PS_MODULE_DIR_ . 'omise/classes/omise_logger.php';
+    require_once _PS_MODULE_DIR_ . 'omise/classes/payment_order.php';
+}
+
+abstract class OmiseBaseEvent
+{
+    protected $omise_logger;
+    protected $omise_transaction_model;
+    protected $payment_order;
+
+    public function __construct()
+    {
+        $this->omise_logger = new OmiseLogger();
+        $this->omise_transaction_model = new OmiseTransactionModel();
+        $this->payment_order = new PaymentOrder();
+    }
+
+    public abstract function handle($event);
+}

--- a/omise/events/omise_event_charge_complete.php
+++ b/omise/events/omise_event_charge_complete.php
@@ -1,0 +1,51 @@
+<?php
+if (! defined('_PS_VERSION_')) {
+    exit();
+}
+
+if (defined('_PS_MODULE_DIR_')) {
+    require_once _PS_MODULE_DIR_ . 'omise/classes/omise_charge_class.php';
+    require_once _PS_MODULE_DIR_ . 'omise/events/omise_base_event.php';
+}
+
+class OmiseEventChargeComplete extends OmiseBaseEvent
+{
+    const KEY = 'charge.complete';
+
+    /**
+     * @param mixed $event The array of JSON decoded from Omise event object.
+     *
+     * @return bool
+     */
+    public function handle($event)
+    {
+        $charge = $event['data'];
+
+        $id_order = $this->omise_transaction_model->getIdOrder($charge['id']);
+        $order = new Order($id_order);
+
+        if (! Validate::isLoadedObject($order)) {
+            return false;
+        }
+
+        $message = 'Omise Webhooks: an event charge.complete, ' . $event['id'] . ', has been caught.';
+
+        switch ($charge['status']) {
+            case OmiseChargeClass::STATUS_FAILED:
+                $this->payment_order->updateStateToBeCanceled($order);
+
+                $message .= ' The status of order, ' . $id_order . ', has been updated to be Canceled.';
+                $this->omise_logger->add($message);
+                break;
+
+            case OmiseChargeClass::STATUS_SUCCESSFUL:
+                $this->payment_order->updateStateToBeSuccess($order);
+
+                $message .= ' The status of order, ' . $id_order . ', has been updated to be Payment accepted.';
+                $this->omise_logger->add($message);
+                break;
+        }
+
+        return true;
+    }
+}

--- a/omise/events/omise_event_handler.php
+++ b/omise/events/omise_event_handler.php
@@ -1,0 +1,33 @@
+<?php
+if (! defined('_PS_VERSION_')) {
+    exit();
+}
+
+if (defined('_PS_MODULE_DIR_')) {
+    require_once _PS_MODULE_DIR_ . 'omise/events/omise_event_charge_complete.php';
+}
+
+class OmiseEventHandler
+{
+    /**
+     * Call another class to perform function for each event. The class to be used for handling event has been
+     * determined by using the attribute named, key, of Omise event object.
+     *
+     * @param mixed $event The array of JSON decoded from Omise event object.
+     *
+     * @return bool
+     */
+    public function handle($event)
+    {
+        switch ($event['key']) {
+            case OmiseEventChargeComplete::KEY:
+                $omise_event = new OmiseEventChargeComplete();
+                break;
+
+            default:
+                return false;
+        }
+
+        return $omise_event->handle($event);
+    }
+}

--- a/tests/unit/classes/OmiseLoggerTest.php
+++ b/tests/unit/classes/OmiseLoggerTest.php
@@ -1,0 +1,48 @@
+<?php
+use \Mockery as m;
+
+class OmiseLoggerTest extends Mockery\Adapter\Phpunit\MockeryTestCase
+{
+    private $omise_logger;
+
+    public function setup()
+    {
+        $this->omise_logger = new OmiseLogger();
+    }
+
+    public function testAdd_addLogWithoutSeverityParameter_logMustBeAddedWithDefaultSeverity()
+    {
+        $message = 'message';
+
+        m::mock('alias:\Logger')
+            ->shouldReceive('addLog')
+            ->with(
+                $message,
+                OmiseLogger::INFO,
+                null,
+                null,
+                null,
+                true
+            );
+
+        $this->omise_logger->add($message);
+    }
+
+    public function testAdd_addLogWithSeverityParameter_logMustBeAddedWithSpecifiedSeverityParameter()
+    {
+        $message = 'message';
+
+        m::mock('alias:\Logger')
+            ->shouldReceive('addLog')
+            ->with(
+                $message,
+                OmiseLogger::ERROR,
+                null,
+                null,
+                null,
+                true
+            );
+
+        $this->omise_logger->add($message, OmiseLogger::ERROR);
+    }
+}

--- a/tests/unit/controllers/front/OmiseWebhooksModuleFrontControllerTest.php
+++ b/tests/unit/controllers/front/OmiseWebhooksModuleFrontControllerTest.php
@@ -1,6 +1,8 @@
 <?php
 class OmiseWebhooksModuleFrontControllerTest extends PHPUnit_Framework_TestCase
 {
+    private $omise_event;
+    private $omise_webhooks;
     private $omise_webhooks_module_front_controller;
 
     public function setup()
@@ -9,16 +11,99 @@ class OmiseWebhooksModuleFrontControllerTest extends PHPUnit_Framework_TestCase
             ->setMockClassName('ModuleFrontController')
             ->setMethods(
                 array(
+                    '__construct',
                     'setTemplate',
                 )
             )
             ->getMock();
 
+        $this->omise_event = $this->getMockBuilder(get_class(new stdClass()))
+            ->setMethods(
+                array(
+                    'handle',
+                )
+            )
+            ->getMock();
+
+        $this->omise_webhooks = $this->getMockBuilder(get_class(new stdClass()))
+            ->setMockClassName('OmiseWebhooks')
+            ->setMethods(
+                array(
+                    'getRequestBody',
+                    'sendRawHeaderAsBadRequest',
+                )
+            )
+            ->getMock();
+
         $this->omise_webhooks_module_front_controller = new OmiseWebhooksModuleFrontController();
+        $this->omise_webhooks_module_front_controller->setOmiseEventHandler($this->omise_event);
+        $this->omise_webhooks_module_front_controller->setOmiseWebhooks($this->omise_webhooks);
     }
 
-    public function testPostProcess_postProcess_displayOmiseWebhooksPage()
+    public function testPostProcess_theRequestBodyHasNoAttributeNamedKey_sendRawHeaderAsBadRequest()
     {
+        $this->omise_webhooks
+            ->method('getRequestBody')
+            ->willReturn(array());
+
+        $this->omise_webhooks
+            ->expects($this->once())
+            ->method('sendRawHeaderAsBadRequest');
+
+        $this->omise_webhooks_module_front_controller->postProcess();
+    }
+
+    public function testPostProcess_theRequestBodyIsNotTheOmiseEventObject_sendRawHeaderAsBadRequest()
+    {
+        $this->omise_webhooks
+            ->method('getRequestBody')
+            ->willReturn(array(
+                'object' => 'anyObject',
+            ));
+
+        $this->omise_webhooks
+            ->expects($this->once())
+            ->method('sendRawHeaderAsBadRequest');
+
+        $this->omise_webhooks_module_front_controller->postProcess();
+    }
+
+    public function testPostProcess_theRequestBodyIsNull_sendRawHeaderAsBadRequest()
+    {
+        $this->omise_webhooks
+            ->method('getRequestBody')
+            ->willReturn(null);
+
+        $this->omise_webhooks
+            ->expects($this->once())
+            ->method('sendRawHeaderAsBadRequest');
+
+        $this->omise_webhooks_module_front_controller->postProcess();
+    }
+
+    public function testPostProcess_theRequestBodyIsValid_requestMustBeHandled()
+    {
+        $this->omise_webhooks
+            ->method('getRequestBody')
+            ->willReturn(array(
+                'object' => 'event',
+            ));
+
+        $this->omise_event
+            ->expects($this->once())
+            ->method('handle');
+
+        $this->omise_webhooks_module_front_controller->postProcess();
+    }
+
+    public function testPostProcess_theRequestBodyIsValid_templateMustBeSet()
+    {
+        $this->omise_webhooks
+            ->method('getRequestBody')
+            ->willReturn(array(
+                'object' => 'event',
+            ));
+
         $this->omise_webhooks_module_front_controller
             ->expects($this->once())
             ->method('setTemplate')

--- a/tests/unit/events/OmiseEventChargeCompleteTest.php
+++ b/tests/unit/events/OmiseEventChargeCompleteTest.php
@@ -1,0 +1,115 @@
+<?php
+use \Mockery as m;
+
+class OmiseEventChargeCompleteTest extends Mockery\Adapter\Phpunit\MockeryTestCase
+{
+    private $omise_base_event;
+    private $omise_event_charge_complete;
+
+    public function setup()
+    {
+        $this->omise_base_event = $this->getMockBuilder(get_class(new stdClass()))
+            ->setMockClassName('OmiseBaseEvent')
+            ->getMock();
+
+        $omise_logger = $this->getMockBuilder(get_class(new stdClass()))
+            ->setMethods(
+                array(
+                    'add',
+                )
+            )
+            ->getMock();
+
+        $omise_transaction_model = $this->getMockBuilder(get_class(new stdClass()))
+            ->setMethods(
+                array(
+                    'getIdOrder',
+                )
+            )
+            ->getMock();
+
+        $payment_order = $this->getMockBuilder(get_class(new stdClass()))
+            ->setMethods(
+                array(
+                    'updateStateToBeCanceled',
+                    'updateStateToBeSuccess',
+                )
+            )
+            ->getMock();
+
+        m::mock('overload:\Order');
+
+        $this->omise_event_charge_complete = new OmiseEventChargeComplete();
+        $this->omise_event_charge_complete->omise_logger = $omise_logger;
+        $this->omise_event_charge_complete->omise_transaction_model = $omise_transaction_model;
+        $this->omise_event_charge_complete->payment_order = $payment_order;
+    }
+
+    public function testHandle_omiseChargeStatusIsFailed_updatePrestaShopOrderStatusToBeCanceled()
+    {
+        $event = $this->getEventFailedCharge();
+        m::mock('alias:\Validate')
+            ->shouldReceive('isLoadedObject')
+            ->andReturn(true);
+
+        $this->omise_event_charge_complete->payment_order
+            ->expects($this->once())
+            ->method('updateStateToBeCanceled');
+
+        $this->omise_event_charge_complete->handle($event);
+    }
+
+    public function testHandle_omiseChargeStatusIsSuccess_updatePrestaShopOrderStatusToBeSuccess()
+    {
+        $event = $this->getEventSuccessfulCharge();
+        m::mock('alias:\Validate')
+            ->shouldReceive('isLoadedObject')
+            ->andReturn(true);
+
+        $this->omise_event_charge_complete->payment_order
+            ->expects($this->once())
+            ->method('updateStateToBeSuccess');
+
+        $this->omise_event_charge_complete->handle($event);
+    }
+
+    public function testHandle_prestaShopOrderIsNotFound_false()
+    {
+        $event = $this->getEventSuccessfulCharge();
+        m::mock('alias:\Validate')
+            ->shouldReceive('isLoadedObject')
+            ->andReturn(false);
+
+        $this->assertFalse($this->omise_event_charge_complete->handle($event));
+    }
+
+    private function getEventFailedCharge()
+    {
+        $event = array(
+            'object' => 'event',
+            'id' => 'eventId',
+            'data' => array(
+                'object' => 'charge',
+                'id' => 'chargeId',
+                'status' => OmiseChargeClass::STATUS_FAILED,
+            ),
+        );
+
+        return $event;
+    }
+
+    private function getEventSuccessfulCharge()
+    {
+        $event = array(
+            'object' => 'event',
+            'id' => 'eventId',
+            'data' => array(
+                'object' => 'charge',
+                'id' => 'chargeId',
+                'status' => OmiseChargeClass::STATUS_SUCCESSFUL,
+            ),
+        );
+
+        return $event;
+    }
+}

--- a/tests/unit/events/OmiseEventHandlerTest.php
+++ b/tests/unit/events/OmiseEventHandlerTest.php
@@ -1,0 +1,19 @@
+<?php
+class OmiseEventHandlerTest extends PHPUnit_Framework_TestCase
+{
+    private $omise_event_handler;
+
+    public function setup()
+    {
+        $this->omise_event_handler = new OmiseEventHandler();
+    }
+
+    public function testHandle_eventKeyHasNotBeHandled_false()
+    {
+        $event = array(
+            'key' => 'unhandledKey',
+        );
+
+        $this->assertFalse($this->omise_event_handler->handle($event));
+    }
+}


### PR DESCRIPTION
#### 1. Objective

Correctly update a status of PrestaShop order when checkout with Omise internet banking payment.

Note:
To complete the checkout with Omise internet banking payment, the payer need to be redirected off the PrestaShop website to the bank website. After the payer completed their payment on bank website, bank will, 

1. Redirect the payer back to PrestaShop website.
2. Send the notification of payment result to Omise.

Sometimes the notification is delayed or slower than the redirection. This situation causes the Omise can not sure the result of payment.

This problem can be solved by using Omise webhooks. Whenever bank sent the notification of payment result to Omise, Omise will send the notification to the PrestaShop website.

**Related information**:
- Related issue: -
- Related ticket: -

#### 2. Description of change

- Add a logger class, OmiseLogger, to write log message to PrestaShop database.
- Develop the mechanism to handle an Omise event, charge.complete.

#### 3. Quality assurance

**Environments:**

- **Platform**: PrestaShop 1.7.2.4
- **Omise plugin**: Omise PrestaShop 1.3
- **PHP**: 5.6.31

**Details:**

It has 2 test cases.

1. The event is charge.complete, status of charge is successful. Expect the status PrestaShop order has been updated to be Payment accepted (success).

2. The event is charge.complete, status of charge is failed. Expect the status PrestaShop order has been updated to be Canceled.

Steps before test.

1. Configure the Omise Webhooks. By copy the URL from Webhooks endpoint that appeared in PrestaShop back office, Omise setting page, and paste it in Omise dashboard, Webhooks Endpoint.

2. Go to PrestaShop front office and process checkout, at the payment step, select any bank from Omise internet banking payment.

The screenshot below shows the configuration for Omise Webhooks endpoint.

<img width="1280" alt="prestashop-1 7 2 4-configure-omise-webhooks-on-omise-dashboard" src="https://user-images.githubusercontent.com/4145121/33013994-635f55e0-ce18-11e7-8843-e901d38fcb74.png">

Test case 1:

The screenshot below shows Omise dashboard, webhooks detail. In the red boxes, there are show the event is charge.complete and charge status is successful.

<img width="725" alt="omise-dashboard-webhooks-detail-charge complete-and-charge-status-is-successful" src="https://user-images.githubusercontent.com/4145121/33014213-28b75f72-ce19-11e7-986a-4bbb26850ebc.png">

The screenshot below shows PrestaShop back office, order detail. In the red box, it shows order status is payment accepted.

![prestashop-1 7 2 4-order-detail-order-status-is-payment-accepted](https://user-images.githubusercontent.com/4145121/33014295-6f5e9a58-ce19-11e7-8b3f-2f7efb4d72a6.png)

The screenshot below shows PrestaShop back office, logs page. In the red box, it shows log message that the module, Omise PrestaShop, has caught Omise webhooks event and updated PrestaShop order status to be payment accepted.

<img width="1280" alt="prestashop-1 7 2 4-logs-charge complete-event-update-order-status-to-be-payment-accepted" src="https://user-images.githubusercontent.com/4145121/33014337-9514b368-ce19-11e7-9e5e-06104f7406c9.png">

Test case 2:

The screenshot below shows Omise dashboard, webhooks detail. In the red boxes, they show the event is charge.complete and charge status is failed.

<img width="733" alt="omise-dashboard-webhooks-detail-charge complete-and-charge-status-is-failed" src="https://user-images.githubusercontent.com/4145121/33014502-1e99c1aa-ce1a-11e7-822e-b78146dded93.png">

The screenshot below shows PrestaShop back office, order detail. In the red box, it shows order status is canceled.

![prestashop-1 7 2 4-order-detail-order-status-is-canceled](https://user-images.githubusercontent.com/4145121/33014511-274f9856-ce1a-11e7-9906-5ec9855a5722.png)

The screenshot below shows PrestaShop back office, logs page. In the red box, it shows log message that the module, Omise PrestaShop, has caught Omise webhooks event and updated PrestaShop order status to be canceled.

![prestashop-1 7 2 4-logs-charge complete-event-update-order-status-to-be-canceled](https://user-images.githubusercontent.com/4145121/33014527-352d7c9a-ce1a-11e7-8623-dd334982d44f.png)

#### 4. Impact of the change

`-`

#### 5. Priority of change

Normal

#### 6. Additional notes

- [List of Omise events](list-of-all-possible-events).

- The HTML comments appeared in response body, Omise dashboard, webhooks detail, if PrestaShop is run on debug mode.

<img width="857" alt="presashop-debug-mode-html-comments-appeard-on-response-body-omise-dashboard-webhooks-detail" src="https://user-images.githubusercontent.com/4145121/33014799-08cf1ea0-ce1b-11e7-81cb-2cb88539991d.png">