### PR TITLE
Correctly handle the Omise charge, paid status, when redirect back to PrestaShop site

### DIFF
--- a/omise/controllers/front/return.php
+++ b/omise/controllers/front/return.php
@@ -32,10 +32,6 @@ class OmiseReturnModuleFrontController extends OmiseBasePaymentModuleFrontContro
             return false;
         }
 
-        if (! $this->charge->isPaid()) {
-            return false;
-        }
-
         return true;
     }
 
@@ -80,7 +76,9 @@ class OmiseReturnModuleFrontController extends OmiseBasePaymentModuleFrontContro
             return;
         }
 
-        $this->payment_order->updateStateToBeSuccess($this->order);
+        if ($this->charge->isPaid()) {
+            $this->payment_order->updateStateToBeSuccess($this->order);
+        }
 
         $this->setRedirectAfter('index.php?controller=order-confirmation' .
             '&id_cart=' . $id_cart .


### PR DESCRIPTION
#### 1. Objective

Solve the situation that the payment result notification from bank server to Omise server is slower than the redirection of payer from bank site back to PrestaShop site.

In this situation, the status of Omise charge is pending and unpaid.

In other words, when the payer has been redirected back to PrestaShop site but Omise server is not received the payment result from bank, this situation causes the incorrect payment result display at order confirmation page.

**Related information**:
- Related issue: -
- Related ticket: -

#### 2. Description of change

Change the step of condition that checked the Omise paid status.

#### 3. Quality assurance

**Environments:**

- **Platform**: PrestaShop 1.7.2.4
- **Omise plugin**: Omise PrestaShop 1.3
- **PHP**: 5.6.3.1

**Details:**

**Before change:**

The screenshot below shows the incorrect result of order confirmation page. From the screenshot, the error message box has been displayed but it has no any error message. This situation, payment has no error. The Omise charge status is just pending which Omise can not sure the result of payment from bank but the PrestaShop system display the error.

![prestashop-1 7 2 4-omise-prestashop](https://user-images.githubusercontent.com/4145121/33306798-89c625ae-d446-11e7-89b7-bfc7f0edb01d.png)

The screenshot below shows the PrestaShop back office, order detail page. The order status is processing.

![prestashop-1 7 2 4-back-office-order-detail-before-change](https://user-images.githubusercontent.com/4145121/33314348-f05c103a-d45f-11e7-8f66-c8f170638263.png)

The screenshot below shows the Omise dashboard, charge detail page. The charge status is pending and unpaid.

![omise-dashboard-charge-detail-before-change](https://user-images.githubusercontent.com/4145121/33314952-cd6deae2-d461-11e7-9e36-51a73ca80b21.png)

**After change:**

The screenshot below shows the correct result of order confirmation page.

![prestashop-order-confirmation-page-order-is-confirmed](https://user-images.githubusercontent.com/4145121/33314561-9c1fcb78-d460-11e7-9cd4-ecc0c4d7af75.png)

The PrestaShop order status is processing and Omise charge status is pending and unpaid same as the before change.

![prestashop-1 7 2 4-back-office-order-detail-after-change](https://user-images.githubusercontent.com/4145121/33315248-bcf848dc-d462-11e7-8deb-f82215ab1ebb.png)

![omise-dashboard-charge-detail-after-change](https://user-images.githubusercontent.com/4145121/33315041-19334aa8-d462-11e7-8968-da810863ec40.png)

#### 4. Impact of the change

`-`

#### 5. Priority of change

Normal

#### 6. Additional notes

- To reproduce the incorrect result above, it can be done by doing on Omise test account.

Steps to reproduce are:
1. Proceed checkout
2. At the payment step, pay by Omise internet banking
3. Refresh on the Omise internet banking testing page

After submit payment, the system will redirect payer to the Omise internet banking testing page.

From the screenshot below, **refresh the page**.

![omise-internet-banking-testing-page](https://user-images.githubusercontent.com/4145121/33310595-b1add7fc-d454-11e7-9f2a-c50d7569a549.png)

According to the situation that the notification of payment result from bank to Omise server is slower than the redirection of payer from bank site back to PrestaShop site, this situation is not easy to test or simulate without any additional configuration or software such as proxy or mocking.

The steps above can be used to closely simulate this situation without any additional configuration or software.

- This situation can be solved by using Omise webhooks. The Omise webhooks feature that synchronized between Omise charge detail and PrestaShop order detail has been implemented in the pull request, #46.