### PR TITLE
Solve the invalid display of payment result message on PrestaShop order confirmation page

### DIFF
--- a/omise/controllers/front/return.php
+++ b/omise/controllers/front/return.php
@@ -51,13 +51,6 @@ class OmiseReturnModuleFrontController extends OmiseBasePaymentModuleFrontContro
             return false;
         }
 
-        if ($this->order->current_state != $this->payment_order->getOrderStateProcessingInProgress()
-            && $this->order->current_state != $this->payment_order->getOrderStateAcceptedPayment()) {
-            $this->error_message = $this->l('Order status is invalid.');
-
-            return false;
-        }
-
         if ($this->isChargeValid($id_order) == false) {
             return false;
         }


### PR DESCRIPTION
#### 1. Objective

Solve the invalid display of payment result message on PrestaShop order confirmation page.

**Related information**:
- Related issue: -
- Related ticket: -

#### 2. Description of change

Remove a condition checking the current PrestaShop order status when redirect payer back to PrestaShop.

#### 3. Quality assurance

**Environments:**

- **Platform**: PrestaShop 1.7.2.4
- **Omise plugin**: Omise PrestaShop 1.3
- **PHP**: 5.6.31

**Details:**

**Steps to reproduce**

1. Configure the Omise webhooks.
2. Proceed checkout.
3. At the payment step, pay by Omise internet banking.
4. At the Omise internet banking testing page, click Failure button AND IMMEDIATELY push escape (esc) button on keyboard.
5. Refresh page.

The 3rd and 4th steps are the simulation of the situation that the notification via webhooks is faster than the redirection of payer back to PrestaShop site. Pushing the esc button on keyboard makes the redirection has been stopped but the notification via webhooks still working. And then refresh the page on 5th step makes the redirection back to PrestaShop site after the webhooks has been handled by Omise PrestaShop.

The screenshot below shows Omise internet banking testing page. Click Failure button AND IMMEDIATELY push esc button on the keyboard.

![omise-internet-banking-testing-page](https://user-images.githubusercontent.com/4145121/33364775-797255e2-d518-11e7-8155-904cef2e8111.png)

The screenshot below shows the invalid display of payment result message on PrestaShop order confirmation page.

![prestashop-1 7 2 4-omise-prestashop-condition-of-order-status-is-invalid](https://user-images.githubusercontent.com/4145121/33365115-b0eebcd0-d519-11e7-9267-f634bbd8934f.png)

**After change:**

Reproduce the above steps. The system display the error message correctly.

![prestashop-1 7 2 4-omise-prestashop-failed-processing-payment-result-on-order-confirmation-page](https://user-images.githubusercontent.com/4145121/33365481-f85f71a8-d51a-11e7-9c0c-69508830893d.png)

#### 4. Impact of the change

`-`

#### 5. Priority of change

Normal

#### 6. Additional notes

Due to the offsite payment, it has the redirection flow. The offsite payment such as internet banking payment. This offsite payment includes the implementation of Omise webhooks, it is possible that webhooks is faster than redirection. The steps of this situation are;

- Payer completed their payment but the payment is failed. So, Omise charge is failed.
- The notification from bank to Omise was passed or forwarded to the PrestaShop site via Omise webhooks FASTER THAN the redirection of payer back to PrestaShop site.
- Omise PrestaShop handled this webhooks event by changed the PrestaShop order status to be Canceled because Omise charge is failed.
- When the payer has been redirected back to PrestaShop site, the Omise PrestaShop strictly check the current PrestaShop order status but the PrestaShop order status of this payment has been changed to be canceled.

This condition or situation can be happened normally with the payment that has the redirection flow.

So, the condition checking the current PrestaShop order status (the PrestaShop order status was allowed only 2 status, processing and payment accepted) when payer has been redirected back to PrestaShop site should be removed by this pull request.