### PR TITLE
Align card payment form and internet banking payment form to be under their payment option

### DIFF
--- a/omise/views/templates/hook/card_payment.tpl
+++ b/omise/views/templates/hook/card_payment.tpl
@@ -1,4 +1,4 @@
-        <div class="col-sm-12">
+        <div class="additional-information">
           <form id="omise_checkout_form" method="post" action="{$action|escape:'html'}">
             <input id="omise_card_token" name="omise_card_token" type="hidden">
             <div class="row">

--- a/omise/views/templates/hook/card_payment.tpl
+++ b/omise/views/templates/hook/card_payment.tpl
@@ -1,57 +1,57 @@
-        <div class="additional-information">
-          <form id="omise_checkout_form" method="post" action="{$action|escape:'html'}">
-            <input id="omise_card_token" name="omise_card_token" type="hidden">
-            <div class="row">
-              <div class="form-group col-sm-12">
-                <label for="omise_card_number">{l s='Card number' mod='omise'}</label>
-                <input class="form-control" id="omise_card_number" type="text" placeholder="{l s='Card number' mod='omise'}">
-              </div>
-            </div>
-            <div class="row">
-              <div class="form-group col-sm-12">
-                <label for="omise_card_holder_name">{l s='Name on card' mod='omise'}</label>
-                <input class="form-control" id="omise_card_holder_name" type="text" placeholder="{l s='Name on card' mod='omise'}">
-              </div>
-            </div>
-            <div class="row">
-              <div class="col-sm-6">
-                <div class="form-group">
-                  <label for="omise_card_expiration_month">{l s='Expiration month' mod='omise'}</label>
-                  <select class="form-control form-control-select" id="omise_card_expiration_month">
-                    <option value="01">01</option>
-                    <option value="02">02</option>
-                    <option value="03">03</option>
-                    <option value="04">04</option>
-                    <option value="05">05</option>
-                    <option value="06">06</option>
-                    <option value="07">07</option>
-                    <option value="08">08</option>
-                    <option value="09">09</option>
-                    <option value="10">10</option>
-                    <option value="11">11</option>
-                    <option value="12">12</option>
-                  </select>
-                </div>
-              </div>
-              <div class="col-sm-6 pull-right">
-                <div class="form-group">
-                  <label for="omise_card_expiration_year">{l s='Expiration year' mod='omise'}</label>
-                  <select class="form-control form-control-select" id="omise_card_expiration_year">
-                    {html_options values=$list_of_expiration_year output=$list_of_expiration_year}
-                  </select>
-                </div>
-              </div>
-            </div>
-            <div class="row">
-              <div class="col-sm-6">
-                <div class="form-group">
-                  <label for="omise_card_security_code">{l s='Security code' mod='omise'}</label>
-                  <input class="form-control" id="omise_card_security_code" type="password" placeholder="{l s='Security code' mod='omise'}">
-                </div>
-              </div>
-            </div>
-          </form>
+<div class="additional-information">
+  <form id="omise_checkout_form" method="post" action="{$action|escape:'html'}">
+    <input id="omise_card_token" name="omise_card_token" type="hidden">
+    <div class="row">
+      <div class="form-group col-sm-12">
+        <label for="omise_card_number">{l s='Card number' mod='omise'}</label>
+        <input class="form-control" id="omise_card_number" type="text" placeholder="{l s='Card number' mod='omise'}">
+      </div>
+    </div>
+    <div class="row">
+      <div class="form-group col-sm-12">
+        <label for="omise_card_holder_name">{l s='Name on card' mod='omise'}</label>
+        <input class="form-control" id="omise_card_holder_name" type="text" placeholder="{l s='Name on card' mod='omise'}">
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-sm-6">
+        <div class="form-group">
+          <label for="omise_card_expiration_month">{l s='Expiration month' mod='omise'}</label>
+          <select class="form-control form-control-select" id="omise_card_expiration_month">
+            <option value="01">01</option>
+            <option value="02">02</option>
+            <option value="03">03</option>
+            <option value="04">04</option>
+            <option value="05">05</option>
+            <option value="06">06</option>
+            <option value="07">07</option>
+            <option value="08">08</option>
+            <option value="09">09</option>
+            <option value="10">10</option>
+            <option value="11">11</option>
+            <option value="12">12</option>
+          </select>
         </div>
+      </div>
+      <div class="col-sm-6 pull-right">
+        <div class="form-group">
+          <label for="omise_card_expiration_year">{l s='Expiration year' mod='omise'}</label>
+          <select class="form-control form-control-select" id="omise_card_expiration_year">
+            {html_options values=$list_of_expiration_year output=$list_of_expiration_year}
+          </select>
+        </div>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-sm-6">
+        <div class="form-group">
+          <label for="omise_card_security_code">{l s='Security code' mod='omise'}</label>
+          <input class="form-control" id="omise_card_security_code" type="password" placeholder="{l s='Security code' mod='omise'}">
+        </div>
+      </div>
+    </div>
+  </form>
+</div>
 
 <script src="https://cdn.omise.co/omise.js.gz"></script>
 

--- a/omise/views/templates/hook/card_payment.tpl
+++ b/omise/views/templates/hook/card_payment.tpl
@@ -1,7 +1,3 @@
-<div class="row">
-  <div class="col-xs-12">
-    <div class="box">
-      <div class="row">
         <div class="col-sm-12">
           <form id="omise_checkout_form" method="post" action="{$action|escape:'html'}">
             <input id="omise_card_token" name="omise_card_token" type="hidden">
@@ -56,10 +52,6 @@
             </div>
           </form>
         </div>
-      </div>
-    </div>
-  </div>
-</div>
 
 <script src="https://cdn.omise.co/omise.js.gz"></script>
 

--- a/omise/views/templates/hook/internet_banking_payment.tpl
+++ b/omise/views/templates/hook/internet_banking_payment.tpl
@@ -1,7 +1,3 @@
-<div class="row">
-  <div class="col-xs-12">
-    <div class="box">
-      <div class="row">
         <div class="col-sm-12">
           <form id="omise-internet-banking-payment-form" method="post" action="{$link->getModuleLink('omise', 'internetbankingpayment', [], true)|escape:'html'}">
             <ul class="omise-internet-banking">
@@ -56,10 +52,6 @@
             </ul>
           </form>
         </div>
-      </div>
-    </div>
-  </div>
-</div>
 
 <div id="omise-message" hidden="hidden">
   <p class="fancybox-error">{l s='Please select a bank before continuing.' js=1 mod='omise'}</p>

--- a/omise/views/templates/hook/internet_banking_payment.tpl
+++ b/omise/views/templates/hook/internet_banking_payment.tpl
@@ -1,4 +1,4 @@
-        <div class="col-sm-12">
+        <div class="additional-information">
           <form id="omise-internet-banking-payment-form" method="post" action="{$link->getModuleLink('omise', 'internetbankingpayment', [], true)|escape:'html'}">
             <ul class="omise-internet-banking">
               <li class="item">

--- a/omise/views/templates/hook/internet_banking_payment.tpl
+++ b/omise/views/templates/hook/internet_banking_payment.tpl
@@ -1,57 +1,57 @@
-        <div class="additional-information">
-          <form id="omise-internet-banking-payment-form" method="post" action="{$link->getModuleLink('omise', 'internetbankingpayment', [], true)|escape:'html'}">
-            <ul class="omise-internet-banking">
-              <li class="item">
-                <input id="omise-internet-banking-scb" name="offsite" type="radio" value="internet_banking_scb" autocomplete="off">
-                <label for="omise-internet-banking-scb">
-                  <div class="omise-logo-wrapper scb">
-                    <img src="/modules/omise/img/scb.svg" class="scb">
-                  </div>
-                  <div class="omise-bank-text-wrapper">
-                    <span class="title">{l s='Siam Commercial Bank' mod='omise'}</span><br>
-                    <span class="secondary-text">{l s='Fee: 15 THB (same zone), 30 THB (out zone)' mod='omise'}</span>
-                  </div>
-                </label>
-              </li>
-              <li class="item">
-                <input id="omise-internet-banking-ktb" name="offsite" type="radio" value="internet_banking_ktb" autocomplete="off">
-                <label for="omise-internet-banking-ktb">
-                  <div class="omise-logo-wrapper ktb">
-                    <img src="/modules/omise/img/ktb.svg" class="ktb">
-                  </div>
-                  <div class="omise-bank-text-wrapper">
-                    <span class="title">{l s='Krungthai Bank' mod='omise'}</span><br>
-                    <span class="secondary-text">{l s='Fee: 15 THB (same zone), 15 THB (out zone)' mod='omise'}</span>
-                  </div>
-                </label>
-              </li>
-              <li class="item">
-                <input id="omise-internet-banking-bay" name="offsite" type="radio" value="internet_banking_bay" autocomplete="off">
-                <label for="omise-internet-banking-bay">
-                  <div class="omise-logo-wrapper bay">
-                    <img src="/modules/omise/img/bay.svg" class="bay">
-                  </div>
-                  <div class="omise-bank-text-wrapper">
-                    <span class="title">{l s='Krungsri Bank' mod='omise'}</span><br>
-                    <span class="secondary-text">{l s='Fee: 15 THB (same zone), 15 THB (out zone)' mod='omise'}</span>
-                  </div>
-                </label>
-              </li>
-              <li class="item">
-                <input id="omise-internet-banking-bbl" name="offsite" type="radio" value="internet_banking_bbl" autocomplete="off">
-                <label for="omise-internet-banking-bbl">
-                  <div class="omise-logo-wrapper bbl">
-                    <img src="/modules/omise/img/bbl.svg" class="bbl">
-                  </div>
-                  <div class="omise-bank-text-wrapper">
-                    <span class="title">{l s='Bangkok Bank' mod='omise'}</span><br>
-                    <span class="secondary-text">{l s='Fee: 15 THB (same zone), 20 THB (out zone)' mod='omise'}</span>
-                  </div>
-                </label>
-              </li>
-            </ul>
-          </form>
-        </div>
+<div class="additional-information">
+  <form id="omise-internet-banking-payment-form" method="post" action="{$link->getModuleLink('omise', 'internetbankingpayment', [], true)|escape:'html'}">
+    <ul class="omise-internet-banking">
+      <li class="item">
+        <input id="omise-internet-banking-scb" name="offsite" type="radio" value="internet_banking_scb" autocomplete="off">
+        <label for="omise-internet-banking-scb">
+          <div class="omise-logo-wrapper scb">
+            <img src="/modules/omise/img/scb.svg" class="scb">
+          </div>
+          <div class="omise-bank-text-wrapper">
+            <span class="title">{l s='Siam Commercial Bank' mod='omise'}</span><br>
+            <span class="secondary-text">{l s='Fee: 15 THB (same zone), 30 THB (out zone)' mod='omise'}</span>
+          </div>
+        </label>
+      </li>
+      <li class="item">
+        <input id="omise-internet-banking-ktb" name="offsite" type="radio" value="internet_banking_ktb" autocomplete="off">
+        <label for="omise-internet-banking-ktb">
+          <div class="omise-logo-wrapper ktb">
+            <img src="/modules/omise/img/ktb.svg" class="ktb">
+          </div>
+          <div class="omise-bank-text-wrapper">
+            <span class="title">{l s='Krungthai Bank' mod='omise'}</span><br>
+            <span class="secondary-text">{l s='Fee: 15 THB (same zone), 15 THB (out zone)' mod='omise'}</span>
+          </div>
+        </label>
+      </li>
+      <li class="item">
+        <input id="omise-internet-banking-bay" name="offsite" type="radio" value="internet_banking_bay" autocomplete="off">
+        <label for="omise-internet-banking-bay">
+          <div class="omise-logo-wrapper bay">
+            <img src="/modules/omise/img/bay.svg" class="bay">
+          </div>
+          <div class="omise-bank-text-wrapper">
+            <span class="title">{l s='Krungsri Bank' mod='omise'}</span><br>
+            <span class="secondary-text">{l s='Fee: 15 THB (same zone), 15 THB (out zone)' mod='omise'}</span>
+          </div>
+        </label>
+      </li>
+      <li class="item">
+        <input id="omise-internet-banking-bbl" name="offsite" type="radio" value="internet_banking_bbl" autocomplete="off">
+        <label for="omise-internet-banking-bbl">
+          <div class="omise-logo-wrapper bbl">
+            <img src="/modules/omise/img/bbl.svg" class="bbl">
+          </div>
+          <div class="omise-bank-text-wrapper">
+            <span class="title">{l s='Bangkok Bank' mod='omise'}</span><br>
+            <span class="secondary-text">{l s='Fee: 15 THB (same zone), 20 THB (out zone)' mod='omise'}</span>
+          </div>
+        </label>
+      </li>
+    </ul>
+  </form>
+</div>
 
 <div id="omise-message" hidden="hidden">
   <p class="fancybox-error">{l s='Please select a bank before continuing.' js=1 mod='omise'}</p>


### PR DESCRIPTION
#### 1. Objective

Refer to the new feature development, save card, this new feature will has more options for the card that payer specified to save on the system. The payment option and the saved card options are hard to distinguish.

So, it is better to make the form to be under their payment option.

**Related information**:
- Related issue: -
- Related ticket: -

#### 2. Description of change

Remove unnecessary HTML elements and apply a defined CSS class of PrestaShop, `additional-information` to both Omise card payment form and Omise internet banking payment form.

#### 3. Quality assurance

**Environments:**

- **Platform**: PrestaShop 1.7.2.4
- **Omise plugin**: Omise PrestaShop 1.4
- **PHP version**: 5.6.32
- **Web browsers**: Google Chrome 63.0, Mozilla Firefox 57.0.1, Opera 49.0, and Safari 11.0.2.

**Details:**

**Before change:**

The screenshot below shows PrestaShop payment step from Safari. The HTML elements of each payment options have been modified to be displayed. The red line has been drawn to indicate that part of Omise card payment form and Omise internet banking from were displayed the same level as their payment options and they are exceed other payment options.

![prestashop-1 7 2 4-payment-step-omise-card-payment-and-omise-internet-banking-payment-form](https://user-images.githubusercontent.com/4145121/34144601-dbf6045a-e4c4-11e7-98d4-f01c04a95479.png)

**After change:**

The screenshot below shows PrestaShop payment step from Safari. The Omise card payment form and Omise internet banking form have been displayed to be under their payment option.

![prestashop-1 7 2 4-payment-step-omise-card-payment-and-omise-internet-banking-payment-form-after-change](https://user-images.githubusercontent.com/4145121/34145268-ca2a7cd0-e4c7-11e7-8c0e-3ee6dbdd6a95.png)

The screenshot below shows PrestaShop payment step from Google Chrome.

<img width="835" alt="prestashop-1 7 2 4-payment-step-omise-card-payment-and-omise-internet-banking-payment-form-google-chrome" src="https://user-images.githubusercontent.com/4145121/34145513-fb09786e-e4c8-11e7-8f3c-faf751304bec.png">

The screenshot below shows PrestaShop payment step from Mozilla Firefox.

<img width="825" alt="prestashop-1 7 2 4-payment-step-omise-card-payment-and-omise-internet-banking-payment-form-mozilla-firefox" src="https://user-images.githubusercontent.com/4145121/34145715-d107d6cc-e4c9-11e7-873b-bb4c403fbe76.png">

The screenshot below shows PrestaShop payment step from Opera.

<img width="828" alt="prestashop-1 7 2 4-payment-step-omise-card-payment-and-omise-internet-banking-payment-form-opera" src="https://user-images.githubusercontent.com/4145121/34145720-d7d560fa-e4c9-11e7-961a-229b9fc4d4a8.png">

#### 4. Impact of the change

`-`

#### 5. Priority of change

Normal

#### 6. Additional notes

`-`