### PR TITLE
Add a checkbox, Remember this card, to card payment form

### DIFF
--- a/omise/views/templates/hook/card_payment.tpl
+++ b/omise/views/templates/hook/card_payment.tpl
@@ -1,53 +1,43 @@
 <div class="additional-information">
   <form id="omise_checkout_form" method="post" action="{$action|escape:'html'}">
     <input id="omise_card_token" name="omise_card_token" type="hidden">
+    <div class="form-group">
+      <label for="omise_card_number">{l s='Card number' mod='omise'}</label>
+      <input class="form-control" id="omise_card_number" type="text" placeholder="{l s='Card number' mod='omise'}">
+    </div>
+    <div class="form-group">
+      <label for="omise_card_holder_name">{l s='Name on card' mod='omise'}</label>
+      <input class="form-control" id="omise_card_holder_name" type="text" placeholder="{l s='Name on card' mod='omise'}">
+    </div>
     <div class="row">
-      <div class="form-group col-sm-12">
-        <label for="omise_card_number">{l s='Card number' mod='omise'}</label>
-        <input class="form-control" id="omise_card_number" type="text" placeholder="{l s='Card number' mod='omise'}">
+      <div class="form-group col-sm-6">
+        <label for="omise_card_expiration_month">{l s='Expiration month' mod='omise'}</label>
+        <select class="form-control form-control-select" id="omise_card_expiration_month">
+          <option value="01">01</option>
+          <option value="02">02</option>
+          <option value="03">03</option>
+          <option value="04">04</option>
+          <option value="05">05</option>
+          <option value="06">06</option>
+          <option value="07">07</option>
+          <option value="08">08</option>
+          <option value="09">09</option>
+          <option value="10">10</option>
+          <option value="11">11</option>
+          <option value="12">12</option>
+        </select>
+      </div>
+      <div class="form-group col-sm-6">
+        <label for="omise_card_expiration_year">{l s='Expiration year' mod='omise'}</label>
+        <select class="form-control form-control-select" id="omise_card_expiration_year">
+          {html_options values=$list_of_expiration_year output=$list_of_expiration_year}
+        </select>
       </div>
     </div>
     <div class="row">
-      <div class="form-group col-sm-12">
-        <label for="omise_card_holder_name">{l s='Name on card' mod='omise'}</label>
-        <input class="form-control" id="omise_card_holder_name" type="text" placeholder="{l s='Name on card' mod='omise'}">
-      </div>
-    </div>
-    <div class="row">
-      <div class="col-sm-6">
-        <div class="form-group">
-          <label for="omise_card_expiration_month">{l s='Expiration month' mod='omise'}</label>
-          <select class="form-control form-control-select" id="omise_card_expiration_month">
-            <option value="01">01</option>
-            <option value="02">02</option>
-            <option value="03">03</option>
-            <option value="04">04</option>
-            <option value="05">05</option>
-            <option value="06">06</option>
-            <option value="07">07</option>
-            <option value="08">08</option>
-            <option value="09">09</option>
-            <option value="10">10</option>
-            <option value="11">11</option>
-            <option value="12">12</option>
-          </select>
-        </div>
-      </div>
-      <div class="col-sm-6 pull-right">
-        <div class="form-group">
-          <label for="omise_card_expiration_year">{l s='Expiration year' mod='omise'}</label>
-          <select class="form-control form-control-select" id="omise_card_expiration_year">
-            {html_options values=$list_of_expiration_year output=$list_of_expiration_year}
-          </select>
-        </div>
-      </div>
-    </div>
-    <div class="row">
-      <div class="col-sm-6">
-        <div class="form-group">
-          <label for="omise_card_security_code">{l s='Security code' mod='omise'}</label>
-          <input class="form-control" id="omise_card_security_code" type="password" placeholder="{l s='Security code' mod='omise'}">
-        </div>
+      <div class="form-group col-sm-6">
+        <label for="omise_card_security_code">{l s='Security code' mod='omise'}</label>
+        <input class="form-control" id="omise_card_security_code" type="password" placeholder="{l s='Security code' mod='omise'}">
       </div>
     </div>
   </form>

--- a/omise/views/templates/hook/card_payment.tpl
+++ b/omise/views/templates/hook/card_payment.tpl
@@ -40,6 +40,13 @@
         <input class="form-control" id="omise_card_security_code" type="password" placeholder="{l s='Security code' mod='omise'}">
       </div>
     </div>
+    <div class="form-group">
+      <div class="form-check">
+        <label class="form-check-label">
+          <input class="form-check-input" type="checkbox"> {l s='Remember this card' mod='omise'}
+        </label>
+      </div>
+    </div>
   </form>
 </div>
 


### PR DESCRIPTION
#### 1. Objective

Add a checkbox, Remember this card, to card payment form.

**Related information**:
- Related issue: -
- Related ticket: -

#### 2. Description of change

- Remove unnecessary HTML elements and CSS classes.
- Add a checkbox to the bottom of card payment form.

#### 3. Quality assurance

**Environments:**

- **Platform**: PrestaShop 1.7.2.4
- **Omise plugin**: Omise PrestaShop 1.4
- **PHP**: 5.6.32
- **Web browsers**: Google Chrome 63.0, Mozilla Firefox 57.0.1, Opera 49.0, and Safari 11.0.2.

**Details:**

The screenshot below shows the checkbox, Remember this card, on Google Chrome.

<img width="830" alt="omise-prestashop-card-payment-form-remember-this-card-checkbox-google-chrome" src="https://user-images.githubusercontent.com/4145121/34244275-223bc6dc-e657-11e7-9bb4-f2302699570e.png">

The screenshot below shows the checkbox, Remember this card, on Mozilla Firefox.

<img width="830" alt="omise-prestashop-card-payment-form-remember-this-card-checkbox-mozilla-firefox" src="https://user-images.githubusercontent.com/4145121/34244303-4275fb48-e657-11e7-99f2-406677de7b03.png">

The screenshot below shows the checkbox, Remember this card, on Opera.

<img width="830" alt="omise-prestashop-card-payment-form-remember-this-card-checkbox-opera" src="https://user-images.githubusercontent.com/4145121/34244317-4bd9b062-e657-11e7-8a8e-3284e8d5dbed.png">

The screenshot below shows the checkbox, Remember this card, on Safari.

<img width="830" alt="omise-prestashop-card-payment-form-remember-this-card-checkbox-safari" src="https://user-images.githubusercontent.com/4145121/34244318-5246208e-e657-11e7-808f-42b38a4eface.png">

#### 4. Impact of the change

`-`

#### 5. Priority of change

Normal

#### 6. Additional notes

This pull request contains the change for adding a checkbox, Remember this card, to view only. The process for saving card will be in the next pull request.