### PR TITLE
Create an Omise customer

### DIFF
--- a/omise/classes/omise_charge_class.php
+++ b/omise/classes/omise_charge_class.php
@@ -26,19 +26,25 @@ class OmiseChargeClass
 
     /**
      * @param string $card_token The Omise card token.
+     * @param string $customer_id The Omise customer ID.
      *
      * @return $this
      */
-    public function create($card_token)
+    public function create($card_token, $customer_id = null)
     {
         $charge_request = array(
             'amount' => $this->getAmount(),
-            'card' => $card_token,
             'capture' => 'true',
             'currency' => $this->getCurrencyCode(),
             'description' => $this->getChargeDescription(),
             'metadata' => $this->getMetadata(),
         );
+
+        if (! is_null($customer_id)) {
+            $charge_request['customer'] = $customer_id;
+        } else {
+            $charge_request['card'] = $card_token;
+        }
 
         if ($this->setting->isThreeDomainSecureEnabled()) {
             $charge_request['return_uri'] = $this->getReturnUri();

--- a/omise/classes/omise_customer_class.php
+++ b/omise/classes/omise_customer_class.php
@@ -1,0 +1,54 @@
+<?php
+if (! defined('_PS_VERSION_')) {
+    exit();
+}
+
+if (defined('_PS_MODULE_DIR_')) {
+    require_once _PS_MODULE_DIR_ . 'omise/libraries/omise-php/lib/Omise.php';
+    require_once _PS_MODULE_DIR_ . 'omise/setting.php';
+}
+
+class OmiseCustomerClass
+{
+    protected $customer_response;
+    protected $setting;
+
+    public function __construct()
+    {
+        $this->setSetting(new Setting());
+    }
+
+    /**
+     * @param string $card_token The Omise card token.
+     *
+     * @return $this
+     */
+    public function create($card_token)
+    {
+        $customer_request = array(
+            'card' => $card_token,
+        );
+
+        $this->customer_response = OmiseCustomer::create($customer_request, '', $this->setting->getSecretKey());
+
+        return $this;
+    }
+
+    /**
+     * Return Omise customer ID.
+     *
+     * @return string
+     */
+    public function getId()
+    {
+        return $this->customer_response['id'];
+    }
+
+    /**
+     * @param \Setting $setting The instance of class, Setting.
+     */
+    public function setSetting($setting)
+    {
+        $this->setting = $setting;
+    }
+}

--- a/omise/views/templates/hook/card_payment.tpl
+++ b/omise/views/templates/hook/card_payment.tpl
@@ -43,7 +43,7 @@
     <div class="form-group">
       <div class="form-check">
         <label class="form-check-label">
-          <input class="form-check-input" type="checkbox"> {l s='Remember this card' mod='omise'}
+          <input class="form-check-input" name="omise_save_customer_card" type="checkbox"> {l s='Remember this card' mod='omise'}
         </label>
       </div>
     </div>

--- a/tests/unit/classes/OmiseChargeClassTest.php
+++ b/tests/unit/classes/OmiseChargeClassTest.php
@@ -85,6 +85,16 @@ class OmiseChargeClassTest extends Mockery\Adapter\Phpunit\MockeryTestCase
         $this->omise_charge_class->create('cardToken');
     }
 
+    public function testCreate_createOmiseChargeWithOmiseCustomerId_createOnlyOneOmiseChargeWithCustomerId()
+    {
+        m::mock('alias:\OmiseCharge')
+            ->shouldReceive('create')
+            ->with($this->createChargeRequestWithCustomerId(), '', $this->secret_key)
+            ->once();
+
+        $this->omise_charge_class->create('cardToken', 'customerId');
+    }
+
     public function testCreate_createThreeDomainSecureOmiseCharge_returnUriMustBeAddedToRequest()
     {
         $this->setting
@@ -188,6 +198,20 @@ class OmiseChargeClassTest extends Mockery\Adapter\Phpunit\MockeryTestCase
             'card' => 'cardToken',
             'capture' => 'true',
             'currency' => 'THB',
+            'description' => 'Charge a card using a token from PrestaShop (' . _PS_VERSION_ . ')',
+            'metadata' => array('order_id' => 1234),
+        );
+
+        return $charge_request;
+    }
+
+    private function createChargeRequestWithCustomerId()
+    {
+        $charge_request = array(
+            'amount' => 10025,
+            'capture' => 'true',
+            'currency' => 'THB',
+            'customer' => 'customerId',
             'description' => 'Charge a card using a token from PrestaShop (' . _PS_VERSION_ . ')',
             'metadata' => array('order_id' => 1234),
         );

--- a/tests/unit/classes/OmiseCustomerClassTest.php
+++ b/tests/unit/classes/OmiseCustomerClassTest.php
@@ -1,0 +1,74 @@
+<?php
+use \Mockery as m;
+
+class OmiseCustomerClassTest extends Mockery\Adapter\Phpunit\MockeryTestCase
+{
+    private $omise_customer_class;
+
+    public function setup()
+    {
+        $this->omise_customer_class = new OmiseCustomerClass();
+        $this->omise_customer_class->setSetting($this->getMockSetting());
+    }
+
+    public function testCreate_createOmiseCustomer_createOnlyOneOmiseCustomerWithCompleteRequestParameters()
+    {
+        m::mock('alias:\OmiseCustomer')
+            ->shouldReceive('create')
+            ->with($this->createCustomerRequest(), '', 'secretKey')
+            ->once();
+
+        $this->omise_customer_class->create('cardToken');
+    }
+
+    public function testCreate_successfullyCreateOmiseCustomer_instanceOfOmiseCustomerClassMustBeReturned()
+    {
+        m::mock('alias:\OmiseCustomer')->shouldIgnoreMissing();
+
+        $this->assertInstanceOf(OmiseCustomerClass::class, $this->omise_customer_class->create('cardToken'));
+    }
+
+    public function testGetId_afterSuccessfullyCreateOmiseCustomer_omiseCustomerIdMustBeAvailable()
+    {
+        m::mock('alias:\OmiseCustomer')
+            ->shouldReceive('create')
+            ->andReturn($this->createCustomerResponse());
+
+        $this->omise_customer_class->create('cardToken');
+
+        $this->assertEquals('omiseCustomerId', $this->omise_customer_class->getId());
+    }
+
+    private function createCustomerRequest()
+    {
+        $customer_request = array(
+            'card' => 'cardToken',
+        );
+
+        return $customer_request;
+    }
+
+    private function createCustomerResponse()
+    {
+        $customer_response = array(
+            'id' => 'omiseCustomerId',
+        );
+
+        return $customer_response;
+    }
+
+    private function getMockSetting()
+    {
+        $setting = $this->getMockBuilder(get_class(new Setting()))
+            ->setMethods(
+                array(
+                    'getSecretKey',
+                )
+            )
+            ->getMock();
+
+        $setting->method('getSecretKey')->willReturn('secretKey');
+
+        return $setting;
+    }
+}


### PR DESCRIPTION
#### 1. Objective

Create an Omise customer, if the payer chooses to remember their card at Omise card payment form.

**Related information**:
- Related issue: -
- Related ticket: -

#### 2. Description of change

- Add a class, `OmiseCustomerClass`, to interface with Omise Customer API via library, Omise PHP.
- Add a process to create an Omise Customer before create Omise charge, if the payer chooses to remember their card on card payment form.

#### 3. Quality assurance

**Environments:**

- **Platform**: PrestaShop 1.7.2.4
- **Omise plugin**: Omise PrestaShop 1.4
- **PHP**: 5.6.32

**Details:**

There are 3 test cases.

1. Check out with Omise card payment and select checkbox, Remember this card, expects an Omise customer was created and charged.

2. Check out with Omise card payment and UNSELECT checkbox, Remember this card, expects Omise customer was NOT created but Omise charge was successfully created.

3. Check out with Omise card payment by using failed card number and select checkbox, Remember this card, expects the error occurred, an Omise customer was created and Omise charge is failed.

Test case 1:

The screenshot below shows PrestaShop payment step, checkout with Omise card payment and remember this card check box has been selected.

![omise_prestashop_check_remember_this_card](https://user-images.githubusercontent.com/4145121/34351363-c87c41fc-ea4e-11e7-901d-3c4ce586ac11.png)

The screenshot below shows Omise dashboard, charge detail. Omise charge has been created with Omise customer.

![omise_dashboard_create_omise_charge_with_omise_customer](https://user-images.githubusercontent.com/4145121/34351391-faa1f76c-ea4e-11e7-855c-eb648c75e021.png)

Test case 2:

The screenshot below shows PrestaShop payment step, checkout with Omise card payment and remember this card check box has NOT been selected.

![omise_prestashop_uncheck_remember_this_card](https://user-images.githubusercontent.com/4145121/34351416-259f4942-ea4f-11e7-8e0c-ef90f6416dfa.png)

The screenshot below shows Omise dashboard, charge detail. Omise charge has been created without Omise customer. It has been create with Omise card token.

![omise_dashboard_create_omise_charge_without_omise_customer](https://user-images.githubusercontent.com/4145121/34351427-3bc57aac-ea4f-11e7-961e-cd4c9155edd4.png)

Test case 3:

The screenshot below shows PrestaShop payment step, checkout with Omise card payment, insufficient fund card number and remember this card check box has been selected.

![omise_prestashop_check_remember_this_card_charge_with_insuffient_funds_card_number](https://user-images.githubusercontent.com/4145121/34351461-6af9463c-ea4f-11e7-8435-b5bbc6c0b2c2.png)

The screenshot below shows PrestaShop payment error.

![omise_prestashop_charge_error_insufficient_funds](https://user-images.githubusercontent.com/4145121/34351507-9fa4b7b8-ea4f-11e7-88e4-7370537575c7.png)

The screenshot below shows Omise dashboard, charge detail. Omise charge is failed, insufficient funds. This Omise charge has been created with Omise customer.

![omise_dashboard_charge_with_customer_error_insufficient_funds](https://user-images.githubusercontent.com/4145121/34351515-a9d37616-ea4f-11e7-9f04-ef210d41486c.png)

#### 4. Impact of the change

`-`

#### 5. Priority of change

Normal

#### 6. Additional notes

The process of store Omise customer ID and Omise card ID to database, bind its with payer and display saved cards of each payer will be developed in next pull request.