### PR TITLE
Create a database table, omise_customer

### DIFF
--- a/omise/classes/omise_customer_model.php
+++ b/omise/classes/omise_customer_model.php
@@ -1,0 +1,67 @@
+<?php
+if (! defined('_PS_VERSION_')) {
+    exit();
+}
+
+class OmiseCustomerModel extends ObjectModel
+{
+    /** @var int */
+    public $id_prestashop_customer;
+
+    /** @var string Omise customer ID belong to Omise test account */
+    public $id_omise_test_customer;
+
+    /** @var string Omise customer ID belong to Omise live account */
+    public $id_omise_live_customer;
+
+    /**
+     * @see ObjectModel::$definition
+     */
+    public static $definition = array(
+        'table' => 'omise_customer',
+        'primary' => 'id_prestashop_customer',
+        'fields' => array(
+            'id_prestashop_customer' => array('type' => self::TYPE_INT, 'validate' => 'isUnsignedId', 'required' => true),
+            'id_omise_test_customer' => array('type' => self::TYPE_STRING, 'validate' => 'isString', 'required' => false, 'size' => 255),
+            'id_omise_live_customer' => array('type' => self::TYPE_STRING, 'validate' => 'isString', 'required' => false, 'size' => 255),
+        ),
+    );
+
+    /**
+     * Create a database table that will be used to store the reference between PrestaShop customer ID and Omise
+     * customer ID.
+     *
+     * It is possible that a PrestaShop customer (payer) has two Omise customer ID.
+     *
+     * 1. The Omise customer ID belong to Omise TEST account.
+     * 2. The Omise customer ID belong to Omise LIVE account.
+     *
+     * This situation can be happened by the merchant switching between their Omise test and live account on the Omise
+     * configuration page, PrestaShop back office.
+     *
+     * @return bool
+     */
+    public function createTable()
+    {
+        $sql = 'CREATE TABLE IF NOT EXISTS `' . _DB_PREFIX_ . 'omise_customer` (
+			`id_prestashop_customer` int(10) unsigned NOT NULL,
+			`id_omise_test_customer` varchar(255) NULL,
+			`id_omise_live_customer` varchar(255) NULL,
+			PRIMARY KEY (`id_prestashop_customer`),
+			UNIQUE KEY `id_omise_test_customer` (`id_omise_test_customer`),
+			UNIQUE KEY `id_omise_live_customer` (`id_omise_live_customer`)
+			) ENGINE=' . _MYSQL_ENGINE_ . ' DEFAULT CHARSET=utf8';
+
+        return Db::getInstance()->execute($sql);
+    }
+
+    /**
+     * @return bool
+     */
+    public function dropTable()
+    {
+        $sql = 'DROP TABLE IF EXISTS `' . _DB_PREFIX_ . 'omise_customer`';
+
+        return Db::getInstance()->execute($sql);
+    }
+}

--- a/omise/classes/omise_customer_model.php
+++ b/omise/classes/omise_customer_model.php
@@ -44,13 +44,13 @@ class OmiseCustomerModel extends ObjectModel
     public function createTable()
     {
         $sql = 'CREATE TABLE IF NOT EXISTS `' . _DB_PREFIX_ . 'omise_customer` (
-			`id_prestashop_customer` int(10) unsigned NOT NULL,
-			`id_omise_test_customer` varchar(255) NULL,
-			`id_omise_live_customer` varchar(255) NULL,
-			PRIMARY KEY (`id_prestashop_customer`),
-			UNIQUE KEY `id_omise_test_customer` (`id_omise_test_customer`),
-			UNIQUE KEY `id_omise_live_customer` (`id_omise_live_customer`)
-			) ENGINE=' . _MYSQL_ENGINE_ . ' DEFAULT CHARSET=utf8';
+            `id_prestashop_customer` int(10) unsigned NOT NULL,
+            `id_omise_test_customer` varchar(255) NULL,
+            `id_omise_live_customer` varchar(255) NULL,
+            PRIMARY KEY (`id_prestashop_customer`),
+            UNIQUE KEY `id_omise_test_customer` (`id_omise_test_customer`),
+            UNIQUE KEY `id_omise_live_customer` (`id_omise_live_customer`)
+            ) ENGINE=' . _MYSQL_ENGINE_ . ' DEFAULT CHARSET=utf8';
 
         return Db::getInstance()->execute($sql);
     }

--- a/omise/omise.php
+++ b/omise/omise.php
@@ -6,6 +6,7 @@ if (! defined('_PS_VERSION_')) {
 use PrestaShop\PrestaShop\Core\Payment\PaymentOption;
 
 if (defined('_PS_MODULE_DIR_')) {
+    require_once _PS_MODULE_DIR_ . 'omise/classes/omise_customer_model.php';
     require_once _PS_MODULE_DIR_ . 'omise/classes/omise_transaction_model.php';
     require_once _PS_MODULE_DIR_ . 'omise/libraries/omise-plugin/Omise.php';
     require_once _PS_MODULE_DIR_ . 'omise/checkout_form.php';
@@ -83,6 +84,13 @@ class Omise extends PaymentModule
     protected $checkout_form;
 
     /**
+     * The instance of class, OmiseCustomerModel.
+     *
+     * @var \OmiseCustomerModel
+     */
+    protected $omise_customer_model;
+
+    /**
      * The instance of class, OmiseTransactionModel.
      *
      * @var \OmiseTransactionModel
@@ -114,6 +122,7 @@ class Omise extends PaymentModule
         $this->confirmUninstall       = $this->l('Are you sure you want to uninstall ' . self::MODULE_DISPLAY_NAME . ' module?');
 
         $this->setCheckoutForm(new CheckoutForm());
+        $this->setOmiseCustomerModel(new OmiseCustomerModel());
         $this->setOmiseTransactionModel(new OmiseTransactionModel());
         $this->setSetting(new Setting());
     }
@@ -279,6 +288,7 @@ class Omise extends PaymentModule
             || $this->registerHook('displayOrderConfirmation') == false
             || $this->registerHook('header') == false
             || $this->registerHook('paymentOptions') == false
+            || $this->omise_customer_model->createTable() == false
             || $this->omise_transaction_model->createTable() == false
             || $this->setting->saveTitle(self::DEFAULT_CARD_PAYMENT_TITLE) == false
         ) {
@@ -330,7 +340,8 @@ class Omise extends PaymentModule
         return parent::uninstall()
             && $this->unregisterHook('displayOrderConfirmation')
             && $this->unregisterHook('header')
-            && $this->unregisterHook('paymentOptions');
+            && $this->unregisterHook('paymentOptions')
+            && $this->omise_customer_model->dropTable();
     }
 
     /**
@@ -347,6 +358,14 @@ class Omise extends PaymentModule
     public function setCheckoutForm($checkout_form)
     {
         $this->checkout_form = $checkout_form;
+    }
+
+    /**
+     * @param \OmiseCustomerModel $omise_customer_model The instance of class, OmiseCustomerModel.
+     */
+    public function setOmiseCustomerModel($omise_customer_model)
+    {
+        $this->omise_customer_model = $omise_customer_model;
     }
 
     /**

--- a/omise/upgrade/upgrade-1.5.php
+++ b/omise/upgrade/upgrade-1.5.php
@@ -1,0 +1,15 @@
+<?php
+if (! defined('_PS_VERSION_')) {
+    exit();
+}
+
+if (defined('_PS_MODULE_DIR_')) {
+    require_once _PS_MODULE_DIR_ . 'omise/classes/omise_customer_model.php';
+}
+
+function upgrade_module_1_5($module)
+{
+    $omise_customer_model = new OmiseCustomerModel();
+
+    return $omise_customer_model->createTable();
+}


### PR DESCRIPTION
#### 1. Objective

Create a database table, `omise_customer`, that will be used to store the reference between PrestaShop customer ID and Omise customer ID for the save customer card feature.

**Related information**:
- Related issue: -
- Related ticket: -

#### 2. Description of change

- Add a model class, `OmiseCustomerModel`, this class is used to interface with a database table, `omise_customer`.
- Add a step to create a database table, `omise_customer`, to the module installation process.
- Add a step to remove a database table, `omise_customer`, to the module uninstallation process.
- Add a function to upgrade the module to version 1.5. This function contains a command to create a database table, `omise_customer`.

#### 3. Quality assurance

**Environments:**

- **Platform**: PrestaShop 1.7.2.4
- **Omise plugin**: Omise PrestaShop 1.4
- **PHP**: 5.6.32

**Details:**

According to the [PrestaShop module upgrade mechanism](http://doc.prestashop.com/display/PS17/Enabling+the+Auto-Update), the version of Omise PrestaShop will be changed from 1.4 to 1.5 for testing purpose on the developer environment.

There are 2 situations for testing.

1. The Omise PrestaShop version 1.4 was installed.

- Install the Omise PrestaShop version 1.5 expects the `omise_customer` database table is created.
- Uninstall the Omise PrestaShop expects the `omise_customer` database table is removed.

2. The Omise PrestaShop was NOT installed. The test cases and expectations are the same as the first situation.

Test case 1:

The screenshot below shows the Omise PrestaShop version 1.4 is installed.

![prestashop_back_office_omise_prestashop_1 4_is_installed](https://user-images.githubusercontent.com/4145121/34517510-d98c0274-f0ad-11e7-89b1-7fe914a83878.png)

The screenshot below shows the Omise PrestaShop version 1.5 has been installed after version 1.4.

![prestashop_back_office_omise_prestashop_1 5_is_installed](https://user-images.githubusercontent.com/4145121/34517713-c3322f52-f0ae-11e7-9b42-b346173cc617.png)

The screenshot below shows the `omise_customer` database table has been created.

<img width="550" alt="omise_customer_database_table_has_been_created" src="https://user-images.githubusercontent.com/4145121/34517739-e4ac3d62-f0ae-11e7-8650-324fc475cde8.png">

The screenshot below shows the Omise PrestaShop was uninstalled.

![prestashop_back_office_omise_prestashop_is_uninstalled](https://user-images.githubusercontent.com/4145121/34517802-2f16b7d8-f0af-11e7-826c-b16d51eb903a.png)

The screenshot below shows the `omise_customer` database table has been removed.

<img width="578" alt="omise_customer_database_table_has_been_removed" src="https://user-images.githubusercontent.com/4145121/34517847-59bc946c-f0af-11e7-9be3-f1860394f8f0.png">

Test case 2:

The screenshot below shows the Omise PrestaShop 1.5 has been installed without version 1.4.

![prestashop_back_office_omise_prestashop_1 5_is_installed_without_1 4](https://user-images.githubusercontent.com/4145121/34518041-1531f71e-f0b0-11e7-9f8c-5b6cfb51ed7a.png)

The screenshot below shows the `omise_customer` database table has been created.

<img width="574" alt="omise_customer_database_table_has_been_created_test_case_2" src="https://user-images.githubusercontent.com/4145121/34518127-907a5d4e-f0b0-11e7-95fd-313305eec04d.png">

The screenshot below shows the `omise_customer` database table has been removed after uninstalled the Omise PrestaShop.

<img width="574" alt="omise_customer_database_table_has_been_removed_test_case_2" src="https://user-images.githubusercontent.com/4145121/34518145-a3a09794-f0b0-11e7-9811-c04c0ccd54bb.png">

#### 4. Impact of the change

`-`

#### 5. Priority of change

Normal

#### 6. Additional notes

`-`