### PR TITLE
Removes mention of specific internet banking charges

### DIFF
--- a/omise/css/omise_internet_banking.css
+++ b/omise/css/omise_internet_banking.css
@@ -27,7 +27,7 @@
   width: 30px;
   height: 30px;
 }
-.omise-internet-banking .omise-bank-text-wrapper { display: inline-block; line-height:38px; }
+.omise-internet-banking .title { line-height:38px; }
 .omise-internet-banking .scb { background: #4e2e7f none repeat scroll 0 0; }
 .omise-internet-banking .ktb { background: #1ba5e1 none repeat scroll 0 0; }
 .omise-internet-banking .bay { background: #fec43b none repeat scroll 0 0; }

--- a/omise/css/omise_internet_banking.css
+++ b/omise/css/omise_internet_banking.css
@@ -27,11 +27,7 @@
   width: 30px;
   height: 30px;
 }
-.omise-internet-banking .omise-bank-text-wrapper { display: inline-block; }
-.omise-internet-banking .secondary-text {
-  font-size: 80%;
-  color: #aaa;
-}
+.omise-internet-banking .omise-bank-text-wrapper { display: inline-block; line-height:38px; }
 .omise-internet-banking .scb { background: #4e2e7f none repeat scroll 0 0; }
 .omise-internet-banking .ktb { background: #1ba5e1 none repeat scroll 0 0; }
 .omise-internet-banking .bay { background: #fec43b none repeat scroll 0 0; }

--- a/omise/views/templates/hook/internet_banking_payment.tpl
+++ b/omise/views/templates/hook/internet_banking_payment.tpl
@@ -12,8 +12,7 @@
                     <img src="/modules/omise/img/scb.svg" class="scb">
                   </div>
                   <div class="omise-bank-text-wrapper">
-                    <span class="title">{l s='Siam Commercial Bank' mod='omise'}</span><br>
-                    <span class="secondary-text">{l s='Fee: 15 THB (same zone), 30 THB (out zone)' mod='omise'}</span>
+                    <span class="title">{l s='Siam Commercial Bank' mod='omise'}</span>
                   </div>
                 </label>
               </li>
@@ -24,8 +23,7 @@
                     <img src="/modules/omise/img/ktb.svg" class="ktb">
                   </div>
                   <div class="omise-bank-text-wrapper">
-                    <span class="title">{l s='Krungthai Bank' mod='omise'}</span><br>
-                    <span class="secondary-text">{l s='Fee: 15 THB (same zone), 15 THB (out zone)' mod='omise'}</span>
+                    <span class="title">{l s='Krungthai Bank' mod='omise'}</span>
                   </div>
                 </label>
               </li>
@@ -36,8 +34,7 @@
                     <img src="/modules/omise/img/bay.svg" class="bay">
                   </div>
                   <div class="omise-bank-text-wrapper">
-                    <span class="title">{l s='Krungsri Bank' mod='omise'}</span><br>
-                    <span class="secondary-text">{l s='Fee: 15 THB (same zone), 15 THB (out zone)' mod='omise'}</span>
+                    <span class="title">{l s='Krungsri Bank' mod='omise'}</span>
                   </div>
                 </label>
               </li>
@@ -48,12 +45,12 @@
                     <img src="/modules/omise/img/bbl.svg" class="bbl">
                   </div>
                   <div class="omise-bank-text-wrapper">
-                    <span class="title">{l s='Bangkok Bank' mod='omise'}</span><br>
-                    <span class="secondary-text">{l s='Fee: 15 THB (same zone), 20 THB (out zone)' mod='omise'}</span>
+                    <span class="title">{l s='Bangkok Bank' mod='omise'}</span>
                   </div>
                 </label>
               </li>
             </ul>
+            <div class="fee-warning"><label>{l s='Your bank may charge a small fee for internet banking payments.' mod='omise'}</label></div>
           </form>
         </div>
       </div>

--- a/omise/views/templates/hook/internet_banking_payment.tpl
+++ b/omise/views/templates/hook/internet_banking_payment.tpl
@@ -11,9 +11,7 @@
                   <div class="omise-logo-wrapper scb">
                     <img src="/modules/omise/img/scb.svg" class="scb">
                   </div>
-                  <div class="omise-bank-text-wrapper">
-                    <span class="title">{l s='Siam Commercial Bank' mod='omise'}</span>
-                  </div>
+                  <span class="title">{l s='Siam Commercial Bank' mod='omise'}</span>
                 </label>
               </li>
               <li class="item">
@@ -22,9 +20,7 @@
                   <div class="omise-logo-wrapper ktb">
                     <img src="/modules/omise/img/ktb.svg" class="ktb">
                   </div>
-                  <div class="omise-bank-text-wrapper">
-                    <span class="title">{l s='Krungthai Bank' mod='omise'}</span>
-                  </div>
+                  <span class="title">{l s='Krungthai Bank' mod='omise'}</span>
                 </label>
               </li>
               <li class="item">
@@ -33,9 +29,7 @@
                   <div class="omise-logo-wrapper bay">
                     <img src="/modules/omise/img/bay.svg" class="bay">
                   </div>
-                  <div class="omise-bank-text-wrapper">
-                    <span class="title">{l s='Krungsri Bank' mod='omise'}</span>
-                  </div>
+                  <span class="title">{l s='Krungsri Bank' mod='omise'}</span>
                 </label>
               </li>
               <li class="item">
@@ -44,9 +38,7 @@
                   <div class="omise-logo-wrapper bbl">
                     <img src="/modules/omise/img/bbl.svg" class="bbl">
                   </div>
-                  <div class="omise-bank-text-wrapper">
-                    <span class="title">{l s='Bangkok Bank' mod='omise'}</span>
-                  </div>
+                  <span class="title">{l s='Bangkok Bank' mod='omise'}</span>
                 </label>
               </li>
             </ul>


### PR DESCRIPTION
#### 1. Objective

Replace labels referring to internet banking charges with a general warning that they may be charged a small fee by their bank for these payments

#### 2. Description of change

Modified the relevant template, and css file

#### 3. Quality assurance

Set up a sample store, installed plugin, switch on internet banking payments, viewed checkout page

#### 4. Impact of the change

The internet banking section now has a general warning about bank fees instead of specific fee details.
![image](https://user-images.githubusercontent.com/1510194/40969646-a27ce322-68e2-11e8-8662-55085fab0c23.png)


#### 5. Priority of change

Normal

#### 6. Additional notes

🎶