### PR TITLE
Modifies JS on some payment templates so it works correctly even when run outside of the global context (as occurs in dynamically created script blocks)

### DIFF
--- a/omise/views/templates/hook/1.6/card_payment.tpl
+++ b/omise/views/templates/hook/1.6/card_payment.tpl
@@ -72,7 +72,12 @@
 <script src="https://cdn.omise.co/omise.js.gz"></script>
 
 <script>
-  const omiseCheckout = function omiseCheckout() {
+  
+  // IMPORTANT - this window.xxx stuff looks weird and unnecessary, but it's necessary to make
+  // the JS work correctly when the checkout is in one-page mode. It would appear that
+  // dynamically created script blocks do not run in the global context
+
+  window.omiseCheckout = function omiseCheckout() {
     if (typeof Omise === 'undefined') {
       alert('{l s='Unable to process the payment, loading the external card processing library is failed. Please contact the merchant.' mod='omise'}');
       return false;
@@ -92,7 +97,7 @@
     Omise.createToken('card', card, omiseCreateTokenCallback);
   }
 
-  const omiseCreateTokenCallback = function omiseCreateTokenCallback(statusCode, response) {
+  window.omiseCreateTokenCallback = function omiseCreateTokenCallback(statusCode, response) {
     if (statusCode === 200) {
       document.getElementById('omise_card_token').value = response.id;
       document.getElementById('omise_checkout_form').submit();
@@ -102,7 +107,7 @@
     }
   };
 
-  const omiseCheckoutForm = {
+  window.omiseCheckoutForm = {
     name: document.getElementById('omise_card_holder_name'),
     number: document.getElementById('omise_card_number'),
     expiration_month: document.getElementById('omise_card_expiration_month'),
@@ -112,7 +117,7 @@
     checkout_text: document.getElementById('omise_checkout_text'),
   };
 
-  const omiseLockCheckoutForm = function omiseLockCheckoutForm(form) {
+  window.omiseLockCheckoutForm = function omiseLockCheckoutForm(form) {
     form.name.disabled = true;
     form.number.disabled = true;
     form.expiration_month.disabled = true;
@@ -122,7 +127,7 @@
     form.checkout_text.innerHTML = '{l s='Processing' mod='omise'}';
   };
 
-  const omiseUnlockCheckoutForm = function omiseUnlockCheckoutForm(form) {
+  window.omiseUnlockCheckoutForm = function omiseUnlockCheckoutForm(form) {
     form.name.disabled = false;
     form.number.disabled = false;
     form.expiration_month.disabled = false;

--- a/omise/views/templates/hook/1.6/internet_banking_payment.tpl
+++ b/omise/views/templates/hook/1.6/internet_banking_payment.tpl
@@ -58,14 +58,15 @@
   </div>
 </div>
 
-{strip}
-  {if $conditions}
-    {addJsDefL name=omise_msg_select_bank}{l s='Please select a bank before continuing.' js=1 mod='omise'}{/addJsDefL}
-  {/if}
-{/strip}
 
 <script>
-  const omiseDisplayMessage = function omiseDisplayMessage(message) {
+
+  // IMPORTANT - this window.xxx stuff looks weird and unnecessary, but it's necessary to make
+  // the JS work correctly when the checkout is in one-page mode. It would appear that
+  // dynamically created script blocks do not run in the global context
+  
+  window.omise_msg_select_bank = "{l s='Please select a bank before continuing.' js=1 mod='omise'}";
+  window.omiseDisplayMessage = function omiseDisplayMessage(message) {
     if ($.prototype.fancybox) {
       $.fancybox.open([
           {
@@ -82,7 +83,7 @@
     }
   }
 
-  const omiseHasAnyBankSelected = function omiseHasAnyBankSelected() {
+  window.omiseHasAnyBankSelected = function omiseHasAnyBankSelected() {
     var selectedBank = document.getElementsByName('offsite');
 
     for (var i = 0; i < selectedBank.length; i++) {
@@ -94,7 +95,7 @@
     return false;
   }
 
-  const omiseInternetBankingCheckout = function omiseInternetBankingCheckout(event) {
+  window.omiseInternetBankingCheckout = function omiseInternetBankingCheckout(event) {
     event.preventDefault();
 
     if (omiseHasAnyBankSelected() == false) {
@@ -122,19 +123,21 @@
    *
    * Reference about Uniform, jQuery plugin, on GitHub: https://github.com/square/uniform
    */
-  const omiseRestoreUniformStyle = function omiseRestoreUniformStyle() {
+  window.omiseRestoreUniformStyle = function omiseRestoreUniformStyle() {
     $.uniform.restore('.no-uniform');
   }
 
   document.getElementById('omiseInternetBankingCheckoutButton').addEventListener('click', function(event) {
-    omiseInternetBankingCheckout(event);
+    window.omiseInternetBankingCheckout(event);
   });
 
   window.addEventListener('load', function() {
-    omiseRestoreUniformStyle();
+    window.omiseRestoreUniformStyle();
   });
 
   window.addEventListener('resize', function() {
-    omiseRestoreUniformStyle();
+    window.omiseRestoreUniformStyle();
   });
+
+  window.setTimeout(window.omiseRestoreUniformStyle, 100);
 </script>


### PR DESCRIPTION
#### 1. Objective

Make the "Credit Card" and "Internet Banking" methods work in "One page checkout" mode.

#### 2. Description of change

Modified the JS in the templates for the 2 payment methods so that it works regardless of whether it is run in the global context (it appears that when JS runs in dynamically created script blocks as in the case with the one page checkout, it runs outside of the global context)

#### 3. Quality assurance

I re-tested the affected payment methods in a PrestaShop 1.6 demo shop, with one page checkout switched on.

#### 4. Impact of the change

All payment methods now work regardless of whether the checkout is in one or multi page mode

#### 5. Priority of change

High - this is issue is affecting merchants who are trying to go live

#### 6. Additional notes

I'm glad I spotted this JS context thing - my original solution was wayyyyyy more elaborate