### PR TITLE
Fix version of Prestashop from 1.6.19 to 16.1.19

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Our aim is to support as many versions of PrestaShop as we can.
 **Here's the list of versions we tested on:**
 
 - PrestaShop 1.7.4, PHP 7.0.30
-- PrestaShop 1.6.19, PHP 5.6.30
+- PrestaShop 1.6.1.19, PHP 5.6.30
 
 **Can't find the version you're looking for?**  
 Submit your requirement as an issue to [GitHub's issue channel](https://github.com/omise/omise-prestashop/issues).


### PR DESCRIPTION
Prestashop v.16.1.19 is the correct version.