### PR TITLE
Fixes paths for Internet Banking images

### DIFF
--- a/omise/views/templates/hook/1.6/internet_banking_payment.tpl
+++ b/omise/views/templates/hook/1.6/internet_banking_payment.tpl
@@ -13,7 +13,7 @@
                   <input class="no-uniform" id="omiseInternetBankingScb" name="offsite" type="radio" value="internet_banking_scb" autocomplete="off">
                   <label for="omiseInternetBankingScb">
                     <div class="omise-logo-wrapper scb">
-                      <img src="/modules/omise/img/scb.svg" class="scb">
+                      <img src="{$urls.base_url}/modules/omise/img/scb.svg" class="scb">
                     </div>
                     <span class="title">{l s='Siam Commercial Bank' mod='omise'}</span><br>
                   </label>
@@ -22,7 +22,7 @@
                   <input class="no-uniform" id="omiseInternetBankingKtb" name="offsite" type="radio" value="internet_banking_ktb" autocomplete="off">
                   <label for="omiseInternetBankingKtb">
                     <div class="omise-logo-wrapper ktb">
-                      <img src="/modules/omise/img/ktb.svg" class="ktb">
+                      <img src="{$urls.base_url}/modules/omise/img/ktb.svg" class="ktb">
                     </div>
                     <span class="title">{l s='Krungthai Bank' mod='omise'}</span><br>
                   </label>
@@ -31,7 +31,7 @@
                   <input class="no-uniform" id="omiseInternetBankingBay" name="offsite" type="radio" value="internet_banking_bay" autocomplete="off">
                   <label for="omiseInternetBankingBay">
                     <div class="omise-logo-wrapper bay">
-                      <img src="/modules/omise/img/bay.svg" class="bay">
+                      <img src="{$urls.base_url}/modules/omise/img/bay.svg" class="bay">
                     </div>
                     <span class="title">{l s='Krungsri Bank' mod='omise'}</span><br>
                   </label>
@@ -40,7 +40,7 @@
                   <input class="no-uniform" id="omiseInternetBankingBbl" name="offsite" type="radio" value="internet_banking_bbl" autocomplete="off">
                   <label for="omiseInternetBankingBbl">
                     <div class="omise-logo-wrapper bbl">
-                      <img src="/modules/omise/img/bbl.svg" class="bbl">
+                      <img src="{$urls.base_url}/modules/omise/img/bbl.svg" class="bbl">
                     </div>
                     <span class="title">{l s='Bangkok Bank' mod='omise'}</span><br>
                   </label>

--- a/omise/views/templates/hook/1.7/internet_banking_payment.tpl
+++ b/omise/views/templates/hook/1.7/internet_banking_payment.tpl
@@ -9,7 +9,7 @@
                 <input id="omise-internet-banking-scb" name="offsite" type="radio" value="internet_banking_scb" autocomplete="off">
                 <label for="omise-internet-banking-scb">
                   <div class="omise-logo-wrapper scb">
-                    <img src="/modules/omise/img/scb.svg" class="scb">
+                    <img src="{$urls.base_url}/modules/omise/img/scb.svg" class="scb">
                   </div>
                   <span class="title">{l s='Siam Commercial Bank' mod='omise'}</span>
                 </label>
@@ -18,7 +18,7 @@
                 <input id="omise-internet-banking-ktb" name="offsite" type="radio" value="internet_banking_ktb" autocomplete="off">
                 <label for="omise-internet-banking-ktb">
                   <div class="omise-logo-wrapper ktb">
-                    <img src="/modules/omise/img/ktb.svg" class="ktb">
+                    <img src="{$urls.base_url}/modules/omise/img/ktb.svg" class="ktb">
                   </div>
                   <span class="title">{l s='Krungthai Bank' mod='omise'}</span>
                 </label>
@@ -27,7 +27,7 @@
                 <input id="omise-internet-banking-bay" name="offsite" type="radio" value="internet_banking_bay" autocomplete="off">
                 <label for="omise-internet-banking-bay">
                   <div class="omise-logo-wrapper bay">
-                    <img src="/modules/omise/img/bay.svg" class="bay">
+                    <img src="{$urls.base_url}/modules/omise/img/bay.svg" class="bay">
                   </div>
                   <span class="title">{l s='Krungsri Bank' mod='omise'}</span>
                 </label>
@@ -36,7 +36,7 @@
                 <input id="omise-internet-banking-bbl" name="offsite" type="radio" value="internet_banking_bbl" autocomplete="off">
                 <label for="omise-internet-banking-bbl">
                   <div class="omise-logo-wrapper bbl">
-                    <img src="/modules/omise/img/bbl.svg" class="bbl">
+                    <img src="{$urls.base_url}/modules/omise/img/bbl.svg" class="bbl">
                   </div>
                   <span class="title">{l s='Bangkok Bank' mod='omise'}</span>
                 </label>


### PR DESCRIPTION
#### 1. Objective

Based on a PR received from outside, it would appear the way paths were constructed for the internet banking images was actually incorrect, even though the images were displaying correctly (this was pure luck down to the specific set up of our test site)

#### 2. Description of change

Small changes to both the PrestaShop 1.6 and 1.7 templates for the internet banking payment method

#### 3. Quality assurance

Test the site as normal, making sure the images still appear as expected

#### 4. Impact of the change

IB images should now work with all site configurations

#### 5. Priority of change

Normal

#### 6. Additional notes

C E G