### PR TITLE
Sandbox warning

### DIFF
--- a/omise/css/omise_test_mode.css
+++ b/omise/css/omise_test_mode.css
@@ -1,0 +1,19 @@
+.omise-test-warning {
+    background: #ffcc00;
+    color: #000;
+    font-weight: bold;
+    width: 80%;
+    position: fixed;
+    top: 0;
+    left: 10%;
+    text-align: center;
+    padding: 5px;
+    border-radius: 0 0 10px 10px;
+    border-top: none;
+    opacity: 0.85;
+    z-index: 100000;
+}
+
+.omise-test-warning a, .omise-test-warning a:hover {
+    color: #007;
+}

--- a/omise/js/test_warn.js
+++ b/omise/js/test_warn.js
@@ -1,0 +1,10 @@
+window.addEventListener('load', function() {
+
+	var warning = document.createElement('div'); 
+	warning.innerHTML = omiseText.warning + ' - \
+		<a target="_blank" href="https://www.omise.co/what-are-test-keys-and-live-keys">\
+		[ ' + omiseText.linkText +' ]</a>';
+	warning.className = 'omise-test-warning';
+	document.body.appendChild(warning);
+
+});

--- a/omise/omise.php
+++ b/omise/omise.php
@@ -319,6 +319,13 @@ class Omise extends PaymentModule
             $this->context->controller->addCSS($this->_path . 'css/omise_internet_banking.css', 'all');
             $this->context->controller->addJqueryPlugin('fancybox');
         }
+
+        // Test mode warning
+        if ($this->context->controller->php_self == 'order' && $this->setting->isModuleEnabled() && $this->setting->isSandboxEnabled()) {
+            $this->context->controller->addJS($this->_path . 'js/test_warn.js', true);
+            $this->context->controller->addCSS($this->_path . 'css/omise_test_mode.css', 'all');
+            return $this->display(__FILE__, 'omise_warning_message.tpl');
+        }
     }
 
     public function hookPaymentOptions()

--- a/omise/views/templates/hook/omise_warning_message.tpl
+++ b/omise/views/templates/hook/omise_warning_message.tpl
@@ -1,0 +1,8 @@
+<script type="text/javascript">
+	// <![CDATA[
+	var omiseText = {
+		warning: "{l s='OMISE SANDBOX MODE' mod='omise'}",
+		linkText: "{l s='more info' mod='omise'}"		
+	};
+	//]]>
+</script>


### PR DESCRIPTION
#### 1. Objective

Add a highly visible warning on checkout page so that merchants will easily know if they have left their site in 'Sandbox' mode for payments

#### 2. Description of change

Some CSS and JS are conditionally added to the checkout page if 'sandbox mode' is switched on.

<img width="1445" alt="image" src="https://user-images.githubusercontent.com/1510194/58692422-c5f68780-83b8-11e9-91cb-2fba472bd0ed.png">


#### 3. Quality assurance

Install the plugin in both PrestaShop 1.6 and 1.7 - check that the warning appears/disappears as expected on the checkout page.

#### 4. Impact of the change

Merchants will be far less likely to accidentally leave their sites in sandbox mode

#### 5. Priority of change

Normal

#### 6. Additional notes

None