### PR TITLE
Adds support for more currencies

### DIFF
--- a/omise/libraries/omise-plugin/helpers/charge.php
+++ b/omise/libraries/omise-plugin/helpers/charge.php
@@ -130,7 +130,7 @@ if (! class_exists('OmisePluginHelperCharge')) {
         public static function isCurrentCurrencyApplicable($currency)
         {
             $curr = strtoupper($currency);
-            return array_key_exists($curr, self::$supportedCurrencies);
+            return in_array($curr, self::$supportedCurrencies);
         }
 
         /**

--- a/omise/libraries/omise-plugin/helpers/charge.php
+++ b/omise/libraries/omise-plugin/helpers/charge.php
@@ -63,7 +63,7 @@ if (! class_exists('OmisePluginHelperCharge')) {
         /**
          *
          * @param string $currency
-         * @param $amount
+         * @param numeric $amount
          * @return string
          */
         public static function amount($currency, $amount)

--- a/omise/libraries/omise-plugin/helpers/charge.php
+++ b/omise/libraries/omise-plugin/helpers/charge.php
@@ -2,25 +2,73 @@
 if (! class_exists('OmisePluginHelperCharge')) {
     class OmisePluginHelperCharge
     {
+
+        private static
+            $currencyDecimals = [
+                "BIF" => 0,
+                "CLP" => 0,
+                "DJF" => 0,
+                "GNF" => 0,
+                "ISK" => 0,
+                "JPY" => 0,
+                "KMF" => 0,
+                "KRW" => 0,
+                "PYG" => 0,
+                "RWF" => 0,
+                "UGX" => 0,
+                "UYI" => 0,
+                "VND" => 0,
+                "VUV" => 0,
+                "XAF" => 0,
+                "XOF" => 0,
+                "XPF" => 0,
+                "BHD" => 3,
+                "IQD" => 3,
+                "JOD" => 3,
+                "KWD" => 3,
+                "LYD" => 3,
+                "OMR" => 3,
+                "TND" => 3,
+            ],
+            $defaultCurrencyDecimals = 2,
+            $upportedCurrencies = [
+                'AUD',
+                'CAD',
+                'CHF',
+                'CNY',
+                'DKK',
+                'EUR',
+                'GBP',
+                'HKD',
+                'JPY',
+                'MYR',
+                'THB',
+                'SGD',
+                'USD'
+            ]
+        ;
+
+        /**
+         * Return number of subunits the passed currency has
+         *
+         * @param string $currency
+         * @return integer
+         */
+        public static function subUnitsFor($curr) {
+            $c = strtoupper($curr);
+            $decimals = isset(self::$currencyDecimals[$c]) ? self::$currencyDecimals[$c] : self::$defaultCurrencyDecimals;
+            return pow(10, $decimals);
+        }        
+
         /**
          *
          * @param string $currency
-         * @param integer $amount
+         * @param $amount
          * @return string
          */
         public static function amount($currency, $amount)
         {
-            switch (strtoupper($currency)) {
-                case 'GBP':
-                case 'EUR':
-                case 'USD':
-                case 'SGD':
-                case 'THB':
-                    $amount = $amount * 100;
-                    break;
-            }
-
-            return $amount;
+            return $amount * self::subUnitsFor($currency);
         }
 
         /**
@@ -71,6 +119,7 @@ if (! class_exists('OmisePluginHelperCharge')) {
 
         /**
          * Check whether the current currency is supported by the Omise API.
+         * (This could/should probably come from Capbilities API in the future)
          *
          * Now, Omise API has no interface to check the supported currencies.
          * So, the supported currencies have been fixed in this function.
@@ -80,17 +129,8 @@ if (! class_exists('OmisePluginHelperCharge')) {
          */
         public static function isCurrentCurrencyApplicable($currency)
         {
-            switch ($currency) {
-                case 'GBP':
-                case 'EUR':
-                case 'USD':
-                case 'JPY':
-                case 'SGD':
-                case 'THB':
-                    return true;
-            }
-
-            return false;
+            $curr = strtoupper($currency);
+            return array_key_exists($curr, self::$supportedCurrencies);
         }
 
         /**


### PR DESCRIPTION
#### 1. Objective

Add support for the additional currencies that have been launched on the backend recently.

```
TH:

Australian Dollar (AUD)
Swiss Franc (CHF)
Chinese Yuan (CNY)
Danish Krone (DKK)
Euro (EUR)
British Pound (GBP)
Hongkong Dollar (HKD)
Japanese Yen (JPY)
Singapore Dollar (SGD)
US Dollar (USD)

SG:

Australian Dollar (AUD)
Canadian Dollar (CAD)
Swiss Franc (CHF)
China Yuan (CNY)
Euro (EUR)
British Pound (GBP)
Hongkong Dollar (HKD)
Japanese Yen (JPY)
Malaysian Ringgit (MYR)
Thai Baht (THB)
US Dollar (USD)
```

#### 2. Description of change

Modifications to the functions that:

a) Convert amounts to subunits
b) Check if a given currency is supported

#### 3. Quality assurance

Tested on my test sites for PrestaShop 1.6 and 1.7 - attempting payments in the new currencies

#### 4. Impact of the change

Newly added currencies can be used

#### 5. Priority of change

Normal

#### 6. Additional notes

👹