### PR TITLE
Fix small HTTPS issue and prepare 1.7.9 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## [[1.7.9] 2020-04-09](https://github.com/omise/omise-prestashop/releases/tag/v1.7.9)
+- *`Fixed`* Small issue with HTTPS at checkout
+
 ## [[1.7.8] 2020-03-31](https://github.com/omise/omise-prestashop/releases/tag/v1.7.8)
 - *`Fixed`* Small issue with TrueMoney fixed
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Submit your requirement as an issue to [GitHub's issue channel](https://github.c
 
 The instructions below will guide you through all the steps in installing the module.
 
-1. Download the [latest version of Omise PrestaShop](https://github.com/omise/omise-prestashop/releases/download/v1.7.8/omise-prestashop-v1.7.8.zip).
+1. Download the [latest version of Omise PrestaShop](https://github.com/omise/omise-prestashop/releases/download/v1.7.9/omise-prestashop-v1.7.9.zip).
 
 2. Login to your PrestaShop back office and go to **Modules & Services**.
 

--- a/omise/config.xml
+++ b/omise/config.xml
@@ -2,7 +2,7 @@
 <module>
 	<name>omise</name>
 	<displayName><![CDATA[Omise]]></displayName>
-	<version><![CDATA[1.7.8]]></version>
+	<version><![CDATA[1.7.9]]></version>
 	<description><![CDATA[]]></description>
 	<author><![CDATA[Omise]]></author>
 	<tab><![CDATA[payments_gateways]]></tab>

--- a/omise/omise.php
+++ b/omise/omise.php
@@ -31,7 +31,7 @@ class Omise extends PaymentModule
     const
         MODULE_DISPLAY_NAME = 'Omise', // The name that will be display to the user at the back-end
         MODULE_NAME = 'omise', // The name that used to reference in the program
-        MODULE_VERSION = '1.7.8' // The version of the module
+        MODULE_VERSION = '1.7.9' // The version of the module
     ;
 
     public

--- a/omise/payment_methods/_payment_method.php
+++ b/omise/payment_methods/_payment_method.php
@@ -72,7 +72,7 @@ class OmisePaymentMethod
         return count(static::$restrictedToCurrencies) ? in_array($curr, static::$restrictedToCurrencies) : true;
     }
 
-    public static function getLink($method, $params = [], $controller = 'paymentmethod', $ssl = false) 
+    public static function getLink($method, $params = [], $controller = 'paymentmethod', $ssl = true) 
     {
         return self::$context->link->getModuleLink(Omise::MODULE_NAME, $controller, array_merge($params, array('type' => $method)), $ssl);
     }


### PR DESCRIPTION
#### 1. Objective

**Related information:**
Related issue(s): #89 

This fixes a small issue (possibly introduced during refactoring) that was causing issues in environments where HTTPS was being enforced everywhere (no payment methods would work at checkout, customers were just redirected back to the checkout page).

The PR also makes the small preparations necessary for v1.7.9 release with this fix.

#### 2. Description of change

The function responsible for generating links was changed to default to secure.

#### 3. Quality assurance

I worked with the merchant who reported the issue to get him to test it in the environment where the issue was occurring. He confirmed it now worked fine.

#### 4. Impact of the change

Plugin will now work successfully in strict HTTPS only environments

#### 5. Priority of change

Normal

