### PR TITLE
Add transaction ID and set order status to canceled on failed payment.

### DIFF
--- a/omise/payment_methods/_offsite.php
+++ b/omise/payment_methods/_offsite.php
@@ -34,9 +34,6 @@ class OmiseOffsitePaymentMethod extends OmisePaymentMethod
 
         if ($c->charge->isFailed()) {
             $c->error_message = $c->charge->getErrorMessage();
-        }
-
-        if (!empty($c->error_message)) {
             $paymentOrder->updateStateToBeCanceled(new Order($id_order));
             return;
         }

--- a/omise/payment_methods/card.php
+++ b/omise/payment_methods/card.php
@@ -57,6 +57,8 @@ class OmisePaymentMethod_Card extends OmisePaymentMethod
             self::getTitle()
         );
 
+        $id_order = Order::{PRESTASHOP_GET_ORDER_ID_METHOD}(self::$context->cart->id);
+
         try {
             $returnUri = self::getReturnUri(self::$context->cart->id, self::$context->customer->secure_key);
             $c->charge = $omiseCharge->create(Tools::getValue('omise_card_token'), $returnUri);
@@ -66,15 +68,10 @@ class OmisePaymentMethod_Card extends OmisePaymentMethod
             return;
         }
 
-        $id_order = Order::{PRESTASHOP_GET_ORDER_ID_METHOD}(self::$context->cart->id);
-
         $paymentOrder->updatePaymentTransactionId($id_order, $c->charge->getId());
 
         if ($c->charge->isFailed()) {
             $c->error_message = $c->charge->getErrorMessage();
-        }
-
-        if (!empty($c->error_message)) {
             $paymentOrder->updateStateToBeCanceled(new Order($id_order)); // TODO - check if this the right thing to be doing - can we not return to checkout?
             return;
         }

--- a/omise/payment_methods/card.php
+++ b/omise/payment_methods/card.php
@@ -62,18 +62,16 @@ class OmisePaymentMethod_Card extends OmisePaymentMethod
             $c->charge = $omiseCharge->create(Tools::getValue('omise_card_token'), $returnUri);
         } catch (Exception $e) {
             $c->error_message = $e->getMessage();
-            return;
-        }
-
-        if ($c->charge->isFailed()) {
-            $c->error_message = $c->charge->getErrorMessage();
+            $paymentOrder->updateStateToBeCanceled(new Order($id_order));
             return;
         }
 
         $id_order = Order::{PRESTASHOP_GET_ORDER_ID_METHOD}(self::$context->cart->id);
 
-        if (!empty($c->charge)) {
-            $paymentOrder->updatePaymentTransactionId($id_order, $c->charge->getId());
+        $paymentOrder->updatePaymentTransactionId($id_order, $c->charge->getId());
+
+        if ($c->charge->isFailed()) {
+            $c->error_message = $c->charge->getErrorMessage();
         }
 
         if (!empty($c->error_message)) {


### PR DESCRIPTION
## Description

- Update transaction ID after charge is created
- Cancel the order if a payment fails or charge is not created

<img width="1266" alt="Screenshot 2567-11-08 at 09 31 09" src="https://github.com/user-attachments/assets/c2e58855-4d63-4247-a64d-f00edb286bb9">

## Rollback procedure

`default rollback procedure`
